### PR TITLE
Add SDBench and MAI-DxO skeleton implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # Dx0
+
+This repository contains a skeleton implementation of the **SDBench** framework and the
+**MAI-DxO** diagnostic agent. The code outlines core components such as the case
+database, cost estimator, gatekeeper and judge agents, as well as the virtual
+panel used for the "Chain of Debate" workflow.
+
+The project roadmap is tracked in `tasks.yml`.

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -1,0 +1,16 @@
+"""SDBench framework and MAI-DxO skeleton implementation."""
+
+from .case_database import Case, CaseDatabase
+from .cost_estimator import CostEstimator
+from .gatekeeper import Gatekeeper
+from .judge import Judge
+from .protocol import ActionType, build_action
+from .panel import VirtualPanel
+from .orchestrator import Orchestrator
+from .evaluation import Evaluator
+
+__all__ = [
+    "Case", "CaseDatabase", "CostEstimator", "Gatekeeper",
+    "Judge", "ActionType", "build_action", "VirtualPanel",
+    "Orchestrator", "Evaluator",
+]

--- a/sdb/case_database.py
+++ b/sdb/case_database.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import List, Dict
+
+@dataclass
+class Case:
+    id: str
+    summary: str
+    full_text: str
+
+class CaseDatabase:
+    """Stub for CPC case storage."""
+
+    def __init__(self, cases: List[Case]):
+        self.cases = {case.id: case for case in cases}
+
+    def get_case(self, case_id: str) -> Case:
+        return self.cases[case_id]

--- a/sdb/cost_estimator.py
+++ b/sdb/cost_estimator.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+@dataclass
+class TestCost:
+    cpt_code: str
+    price: float
+
+class CostEstimator:
+    """Map tests to CPT codes and prices."""
+
+    def __init__(self, cost_table: Dict[str, TestCost]):
+        self.cost_table = cost_table
+
+    def lookup_cost(self, test_name: str) -> Optional[TestCost]:
+        return self.cost_table.get(test_name)
+
+    def estimate_cost(self, test_name: str) -> float:
+        tc = self.lookup_cost(test_name)
+        if tc:
+            return tc.price
+        # TODO: use language model to estimate missing costs
+        return 0.0

--- a/sdb/evaluation.py
+++ b/sdb/evaluation.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from .cost_estimator import CostEstimator
+from .judge import Judge
+
+@dataclass
+class SessionResult:
+    total_cost: float
+    score: int
+
+class Evaluator:
+    def __init__(self, judge: Judge, cost_estimator: CostEstimator):
+        self.judge = judge
+        self.cost_estimator = cost_estimator
+
+    def evaluate(self, diagnosis: str, truth: str, tests: list) -> SessionResult:
+        judgement = self.judge.evaluate(diagnosis, truth)
+        total_cost = sum(self.cost_estimator.estimate_cost(t) for t in tests)
+        return SessionResult(total_cost=total_cost, score=judgement.score)

--- a/sdb/gatekeeper.py
+++ b/sdb/gatekeeper.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from typing import Dict, Any
+
+from .case_database import CaseDatabase, Case
+
+@dataclass
+class QueryResult:
+    content: str
+    synthetic: bool = False
+
+class Gatekeeper:
+    """Information oracle mediating access to the case."""
+
+    def __init__(self, db: CaseDatabase, case_id: str):
+        self.case = db.get_case(case_id)
+
+    def answer_question(self, query: str) -> QueryResult:
+        """Return relevant snippet from case or synthetic result."""
+        # TODO: restrict to explicit findings and synthesize unseen tests
+        return QueryResult(content="Not implemented")

--- a/sdb/judge.py
+++ b/sdb/judge.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import Dict
+
+@dataclass
+class Judgement:
+    score: int
+    explanation: str
+
+class Judge:
+    """Evaluate diagnosis with physician-authored rubric."""
+
+    def __init__(self, rubric: Dict[str, Any]):
+        self.rubric = rubric
+
+    def evaluate(self, diagnosis: str, truth: str) -> Judgement:
+        # TODO: implement scoring logic
+        return Judgement(score=0, explanation="Not implemented")

--- a/sdb/orchestrator.py
+++ b/sdb/orchestrator.py
@@ -1,0 +1,18 @@
+from .panel import VirtualPanel
+from .gatekeeper import Gatekeeper
+from .protocol import build_action
+
+class Orchestrator:
+    def __init__(self, panel: VirtualPanel, gatekeeper: Gatekeeper):
+        self.panel = panel
+        self.gatekeeper = gatekeeper
+        self.finished = False
+
+    def run_turn(self, case_info: str) -> str:
+        action = self.panel.deliberate(case_info)
+        xml = build_action(action.action_type, action.content)
+        # TODO: send action to gatekeeper and get result
+        result = self.gatekeeper.answer_question(xml)
+        if action.action_type == action.action_type.DIAGNOSIS:
+            self.finished = True
+        return result.content

--- a/sdb/panel.py
+++ b/sdb/panel.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from .protocol import ActionType, build_action
+
+@dataclass
+class PanelAction:
+    action_type: ActionType
+    content: str
+
+class VirtualPanel:
+    """Simulate collaborative panel of doctors."""
+
+    def deliberate(self, case_info: str) -> PanelAction:
+        # TODO: implement Chain of Debate between personas
+        return PanelAction(ActionType.DIAGNOSIS, "Not implemented")

--- a/sdb/protocol.py
+++ b/sdb/protocol.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+class ActionType(Enum):
+    QUESTION = "question"
+    TEST = "test"
+    DIAGNOSIS = "diagnosis"
+
+# Simple helpers for building XML tags
+
+def build_action(action: ActionType, content: str) -> str:
+    return f"<{action.value}>{content}</{action.value}>"

--- a/tasks.yml
+++ b/tasks.yml
@@ -1,0 +1,22 @@
+- phase: "Phase 1: SDBench Framework and Environment Setup"
+  tasks:
+    - id: 1
+      desc: "Curate case database of 304 CPC cases and hold out 56 for hidden test set"
+    - id: 2
+      desc: "Implement cost estimation system mapping tests to CPT codes and prices"
+    - id: 3
+      desc: "Create Gatekeeper agent to deliver case findings and generate synthetic data for off-path queries"
+    - id: 4
+      desc: "Create Judge agent implementing 5-point rubric"
+- phase: "Phase 2: MAI-DxO Agent Implementation and Execution"
+  tasks:
+    - id: 5
+      desc: "Define XML-based interaction protocol for questions, tests, and diagnosis"
+    - id: 6
+      desc: "Implement MAI-DxO virtual panel with five doctor personas"
+    - id: 7
+      desc: "Orchestrate Chain of Debate workflow"
+    - id: 8
+      desc: "Configure runs for different budget modes and ensemble"
+    - id: 9
+      desc: "Perform final evaluation using Judge and Cost Estimator"


### PR DESCRIPTION
## Summary
- outline development plan in `tasks.yml`
- create Python package `sdb` with skeleton modules for the benchmark and agent
- document project purpose in `README`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6869b84164c0832a810bdd7281d0ecf2