### PR TITLE
Add basic functionality for diagnostic framework

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,29 @@
+import argparse
+from sdb import Case, CaseDatabase, Gatekeeper, CostEstimator, VirtualPanel, Orchestrator
+from sdb.cost_estimator import TestCost
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run a simple diagnostic session")
+    parser.add_argument('--case', default='1')
+    args = parser.parse_args()
+
+    # Sample case
+    case = Case(id="1", summary="Patient complains of cough", full_text="History: patient has had a cough for 3 days.")
+    db = CaseDatabase([case])
+    gatekeeper = Gatekeeper(db, args.case)
+    gatekeeper.register_test_result("complete blood count", "normal")
+
+    cost_estimator = CostEstimator({"complete blood count": TestCost("100", 10.0)})
+    panel = VirtualPanel()
+    orchestrator = Orchestrator(panel, gatekeeper)
+
+    turn = 0
+    while not orchestrator.finished and turn < 10:
+        response = orchestrator.run_turn("")
+        print(f"Turn {turn+1}: {response}")
+        turn += 1
+
+
+if __name__ == '__main__':
+    main()

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -1,7 +1,7 @@
 """SDBench framework and MAI-DxO skeleton implementation."""
 
 from .case_database import Case, CaseDatabase
-from .cost_estimator import CostEstimator
+from .cost_estimator import CostEstimator, TestCost
 from .gatekeeper import Gatekeeper
 from .judge import Judge
 from .protocol import ActionType, build_action
@@ -10,7 +10,7 @@ from .orchestrator import Orchestrator
 from .evaluation import Evaluator
 
 __all__ = [
-    "Case", "CaseDatabase", "CostEstimator", "Gatekeeper",
+    "Case", "CaseDatabase", "CostEstimator", "TestCost", "Gatekeeper",
     "Judge", "ActionType", "build_action", "VirtualPanel",
     "Orchestrator", "Evaluator",
 ]

--- a/sdb/case_database.py
+++ b/sdb/case_database.py
@@ -1,5 +1,7 @@
+import json
+import os
 from dataclasses import dataclass
-from typing import List, Dict
+from typing import List, Dict, Iterable
 
 @dataclass
 class Case:
@@ -10,8 +12,41 @@ class Case:
 class CaseDatabase:
     """Stub for CPC case storage."""
 
-    def __init__(self, cases: List[Case]):
+    def __init__(self, cases: Iterable[Case]):
         self.cases = {case.id: case for case in cases}
 
     def get_case(self, case_id: str) -> Case:
         return self.cases[case_id]
+
+    @staticmethod
+    def load_from_json(path: str) -> "CaseDatabase":
+        """Load cases from a JSON file.
+
+        The JSON file should contain a list of objects with ``id``,
+        ``summary`` and ``full_text`` fields.
+        """
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        cases = [Case(**item) for item in data]
+        return CaseDatabase(cases)
+
+    @staticmethod
+    def load_from_directory(path: str) -> "CaseDatabase":
+        """Load cases from a directory of text files.
+
+        Each subdirectory should contain ``summary.txt`` and ``full.txt``
+        files. The subdirectory name is used as the case ``id``.
+        """
+        cases = []
+        for case_id in sorted(os.listdir(path)):
+            case_dir = os.path.join(path, case_id)
+            summary_file = os.path.join(case_dir, "summary.txt")
+            full_file = os.path.join(case_dir, "full.txt")
+            if not os.path.isfile(summary_file) or not os.path.isfile(full_file):
+                continue
+            with open(summary_file, "r", encoding="utf-8") as sf:
+                summary = sf.read().strip()
+            with open(full_file, "r", encoding="utf-8") as ff:
+                full_text = ff.read().strip()
+            cases.append(Case(id=case_id, summary=summary, full_text=full_text))
+        return CaseDatabase(cases)

--- a/sdb/cost_estimator.py
+++ b/sdb/cost_estimator.py
@@ -1,3 +1,4 @@
+import csv
 from dataclasses import dataclass
 from typing import Dict, Optional
 
@@ -10,14 +11,48 @@ class CostEstimator:
     """Map tests to CPT codes and prices."""
 
     def __init__(self, cost_table: Dict[str, TestCost]):
-        self.cost_table = cost_table
+        self.cost_table = {k.lower(): v for k, v in cost_table.items()}
+        self.aliases: Dict[str, str] = {}
+
+    @staticmethod
+    def load_from_csv(path: str) -> "CostEstimator":
+        """Load CPT pricing table from CSV.
+
+        The CSV file is expected to contain ``test_name``, ``cpt_code`` and
+        ``price`` columns. Rows that are missing data are skipped.
+        """
+        table: Dict[str, TestCost] = {}
+        with open(path, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                try:
+                    name = row["test_name"].strip().lower()
+                    cpt = row["cpt_code"].strip()
+                    price = float(row["price"])
+                except Exception:
+                    continue
+                table[name] = TestCost(cpt_code=cpt, price=price)
+        return CostEstimator(table)
 
     def lookup_cost(self, test_name: str) -> Optional[TestCost]:
-        return self.cost_table.get(test_name)
+        key = test_name.strip().lower()
+        if key in self.aliases:
+            key = self.aliases[key]
+        return self.cost_table.get(key)
+
+    def add_aliases(self, mapping: Dict[str, str]):
+        """Register mapping of free text requests to canonical test names."""
+        for k, v in mapping.items():
+            self.aliases[k.lower()] = v.lower()
 
     def estimate_cost(self, test_name: str) -> float:
         tc = self.lookup_cost(test_name)
         if tc:
             return tc.price
-        # TODO: use language model to estimate missing costs
+        # Placeholder fallback cost estimation when CPT code is unknown.
+        # In a full system this could call a language model. Here we return
+        # an average price based on known tests if available.
+        if self.cost_table:
+            avg = sum(tc.price for tc in self.cost_table.values()) / len(self.cost_table)
+            return avg
         return 0.0

--- a/sdb/gatekeeper.py
+++ b/sdb/gatekeeper.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass
 from typing import Dict, Any
+import re
+
+from .protocol import ActionType
 
 from .case_database import CaseDatabase, Case
 
@@ -13,8 +16,44 @@ class Gatekeeper:
 
     def __init__(self, db: CaseDatabase, case_id: str):
         self.case = db.get_case(case_id)
+        self.known_tests: Dict[str, str] = {}
+
+    def register_test_result(self, test_name: str, result: str):
+        """Add known test result for the current case."""
+        self.known_tests[test_name.lower()] = result
 
     def answer_question(self, query: str) -> QueryResult:
         """Return relevant snippet from case or synthetic result."""
-        # TODO: restrict to explicit findings and synthesize unseen tests
-        return QueryResult(content="Not implemented")
+
+        # Very small XML parser for <question>, <test>, <diagnosis>
+        m = re.match(r"<(?P<tag>\w+)>(?P<text>.*)</\w+>", query.strip(), re.S)
+        if not m:
+            return QueryResult("Invalid query", synthetic=True)
+
+        tag = m.group("tag")
+        text = m.group("text").strip()
+
+        if tag == ActionType.DIAGNOSIS.value:
+            # We never reveal the diagnosis
+            return QueryResult("Diagnosis queries are not allowed", synthetic=True)
+
+        if tag == ActionType.QUESTION.value:
+            # Refuse vague or diagnostic questions
+            if any(word in text.lower() for word in ["diagnosis", "differential", "what is wrong"]):
+                return QueryResult("I can only answer explicit questions about findings.", synthetic=True)
+
+            # Search summary and full text for the answer (naive search)
+            for section in [self.case.summary, self.case.full_text]:
+                idx = section.lower().find(text.lower())
+                if idx != -1:
+                    snippet = section[max(0, idx-40): idx+40]
+                    return QueryResult(content=snippet, synthetic=False)
+            return QueryResult("No information available", synthetic=True)
+
+        if tag == ActionType.TEST.value:
+            result = self.known_tests.get(text.lower())
+            if result:
+                return QueryResult(result, synthetic=False)
+            return QueryResult("Synthetic result: normal", synthetic=True)
+
+        return QueryResult("Unknown action", synthetic=True)

--- a/sdb/judge.py
+++ b/sdb/judge.py
@@ -1,5 +1,6 @@
+import difflib
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Any
 
 @dataclass
 class Judgement:
@@ -10,8 +11,35 @@ class Judge:
     """Evaluate diagnosis with physician-authored rubric."""
 
     def __init__(self, rubric: Dict[str, Any]):
+        """Create a judge with a scoring rubric.
+
+        The rubric may define ``exact_threshold`` and ``partial_threshold``
+        similarity ratios. Defaults are 0.9 and 0.6.
+        """
         self.rubric = rubric
+        self.exact_threshold = float(rubric.get("exact_threshold", 0.9))
+        self.partial_threshold = float(rubric.get("partial_threshold", 0.6))
 
     def evaluate(self, diagnosis: str, truth: str) -> Judgement:
-        # TODO: implement scoring logic
-        return Judgement(score=0, explanation="Not implemented")
+        """Score the diagnosis against the truth and return judgement."""
+        d = diagnosis.strip().lower()
+        t = truth.strip().lower()
+        ratio = difflib.SequenceMatcher(None, d, t).ratio()
+
+        if ratio >= self.exact_threshold:
+            score = 5
+            explanation = "Exact or near exact match"
+        elif ratio >= self.partial_threshold:
+            score = 4
+            explanation = "Reasonable partial match"
+        elif d and t and (d in t or t in d):
+            score = 3
+            explanation = "Minor overlap"
+        elif ratio > 0.3:
+            score = 2
+            explanation = "Poor match"
+        else:
+            score = 1
+            explanation = "Incorrect diagnosis"
+
+        return Judgement(score=score, explanation=explanation)

--- a/sdb/orchestrator.py
+++ b/sdb/orchestrator.py
@@ -1,18 +1,22 @@
 from .panel import VirtualPanel
 from .gatekeeper import Gatekeeper
-from .protocol import build_action
+from .protocol import build_action, ActionType
 
 class Orchestrator:
     def __init__(self, panel: VirtualPanel, gatekeeper: Gatekeeper):
         self.panel = panel
         self.gatekeeper = gatekeeper
         self.finished = False
+        self.ordered_tests = []
 
     def run_turn(self, case_info: str) -> str:
         action = self.panel.deliberate(case_info)
         xml = build_action(action.action_type, action.content)
-        # TODO: send action to gatekeeper and get result
         result = self.gatekeeper.answer_question(xml)
-        if action.action_type == action.action_type.DIAGNOSIS:
+
+        if action.action_type == ActionType.TEST:
+            self.ordered_tests.append(action.content)
+        if action.action_type == ActionType.DIAGNOSIS:
             self.finished = True
+
         return result.content

--- a/sdb/panel.py
+++ b/sdb/panel.py
@@ -8,7 +8,22 @@ class PanelAction:
 
 class VirtualPanel:
     """Simulate collaborative panel of doctors."""
+    def __init__(self):
+        self.turn = 0
 
     def deliberate(self, case_info: str) -> PanelAction:
-        # TODO: implement Chain of Debate between personas
-        return PanelAction(ActionType.DIAGNOSIS, "Not implemented")
+        """Very small demo implementation of the Chain of Debate."""
+        self.turn += 1
+
+        if self.turn == 1:
+            # Dr. Hypothesis asks for key symptom information
+            return PanelAction(ActionType.QUESTION, "chief complaint")
+        elif self.turn == 2:
+            # Test-Chooser orders a basic test
+            return PanelAction(ActionType.TEST, "complete blood count")
+        elif self.turn == 3:
+            # Challenger requests additional info
+            return PanelAction(ActionType.QUESTION, "physical examination")
+        else:
+            # Stewardship/Checklist propose a diagnosis to finish
+            return PanelAction(ActionType.DIAGNOSIS, "viral infection")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure the repo root is on sys.path
+ROOT = os.path.dirname(os.path.dirname(__file__))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_cost_estimator.py
+++ b/tests/test_cost_estimator.py
@@ -1,0 +1,22 @@
+import tempfile
+import csv
+from sdb.cost_estimator import CostEstimator, TestCost
+
+
+def test_lookup_and_estimate():
+    data = [
+        {"test_name": "cbc", "cpt_code": "100", "price": "10"},
+        {"test_name": "bmp", "cpt_code": "101", "price": "20"},
+    ]
+    with tempfile.NamedTemporaryFile("w", newline="", delete=False) as f:
+        writer = csv.DictWriter(f, fieldnames=["test_name", "cpt_code", "price"])
+        writer.writeheader()
+        writer.writerows(data)
+        path = f.name
+    ce = CostEstimator.load_from_csv(path)
+    ce.add_aliases({"basic metabolic panel": "bmp"})
+
+    assert ce.lookup_cost("cbc").price == 10.0
+    assert ce.lookup_cost("basic metabolic panel").cpt_code == "101"
+    # Unknown test uses average of known prices => (10+20)/2=15
+    assert ce.estimate_cost("unknown") == 15.0

--- a/tests/test_gatekeeper.py
+++ b/tests/test_gatekeeper.py
@@ -1,0 +1,33 @@
+from sdb.case_database import Case, CaseDatabase
+from sdb.gatekeeper import Gatekeeper
+from sdb.protocol import build_action, ActionType
+
+
+def setup_gatekeeper():
+    case = Case(id="1", summary="Patient complains of cough", full_text="History: patient has had a cough for 3 days.")
+    db = CaseDatabase([case])
+    gk = Gatekeeper(db, "1")
+    gk.register_test_result("complete blood count", "normal")
+    return gk
+
+
+def test_question():
+    gk = setup_gatekeeper()
+    q = build_action(ActionType.QUESTION, "cough")
+    res = gk.answer_question(q)
+    assert "cough" in res.content.lower()
+    assert res.synthetic is False
+
+
+def test_test_query():
+    gk = setup_gatekeeper()
+    q = build_action(ActionType.TEST, "complete blood count")
+    res = gk.answer_question(q)
+    assert res.content == "normal"
+
+
+def test_diagnosis_refusal():
+    gk = setup_gatekeeper()
+    q = build_action(ActionType.QUESTION, "what is the diagnosis?")
+    res = gk.answer_question(q)
+    assert res.synthetic is True

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1,0 +1,12 @@
+from sdb.judge import Judge
+
+
+def test_judge_scoring():
+    rubric = {"exact_threshold": 0.9, "partial_threshold": 0.6}
+    j = Judge(rubric)
+    res = j.evaluate("Influenza", "Influenza")
+    assert res.score == 5
+    res = j.evaluate("Influenza A", "Influenza")
+    assert res.score >= 4
+    res = j.evaluate("Cold", "Influenza")
+    assert res.score <= 2

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -1,0 +1,8 @@
+from sdb.panel import VirtualPanel
+from sdb.protocol import ActionType
+
+
+def test_panel_sequence():
+    panel = VirtualPanel()
+    actions = [panel.deliberate("").action_type for _ in range(4)]
+    assert actions == [ActionType.QUESTION, ActionType.TEST, ActionType.QUESTION, ActionType.DIAGNOSIS]


### PR DESCRIPTION
## Summary
- implement JSON/dir data loaders for `CaseDatabase`
- flesh out `CostEstimator` with CSV loader, aliases, and fallback estimation
- add strict `Gatekeeper` logic and synthetic responses
- implement scoring rubric in `Judge`
- create a simple deliberation workflow for `VirtualPanel`
- expand `Orchestrator` run loop
- provide unit tests and a demo CLI

## Testing
- `pytest -q`
- `python cli.py | head`


------
https://chatgpt.com/codex/tasks/task_e_6869bb0f448c832a80b85a8bc7db8cbc