### PR TITLE
Rename TestCost dataclass

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,6 @@
 import argparse
 from sdb import Case, CaseDatabase, Gatekeeper, CostEstimator, VirtualPanel, Orchestrator
-from sdb.cost_estimator import TestCost
+from sdb.cost_estimator import CptCost
 
 
 def main():
@@ -14,7 +14,7 @@ def main():
     gatekeeper = Gatekeeper(db, args.case)
     gatekeeper.register_test_result("complete blood count", "normal")
 
-    cost_estimator = CostEstimator({"complete blood count": TestCost("100", 10.0)})
+    cost_estimator = CostEstimator({"complete blood count": CptCost("100", 10.0)})
     panel = VirtualPanel()
     orchestrator = Orchestrator(panel, gatekeeper)
 

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -1,7 +1,7 @@
 """SDBench framework and MAI-DxO skeleton implementation."""
 
 from .case_database import Case, CaseDatabase
-from .cost_estimator import CostEstimator, TestCost
+from .cost_estimator import CostEstimator, CptCost
 from .gatekeeper import Gatekeeper
 from .judge import Judge
 from .protocol import ActionType, build_action
@@ -10,7 +10,7 @@ from .orchestrator import Orchestrator
 from .evaluation import Evaluator
 
 __all__ = [
-    "Case", "CaseDatabase", "CostEstimator", "TestCost", "Gatekeeper",
+    "Case", "CaseDatabase", "CostEstimator", "CptCost", "Gatekeeper",
     "Judge", "ActionType", "build_action", "VirtualPanel",
     "Orchestrator", "Evaluator",
 ]

--- a/sdb/cost_estimator.py
+++ b/sdb/cost_estimator.py
@@ -3,14 +3,14 @@ from dataclasses import dataclass
 from typing import Dict, Optional
 
 @dataclass
-class TestCost:
+class CptCost:
     cpt_code: str
     price: float
 
 class CostEstimator:
     """Map tests to CPT codes and prices."""
 
-    def __init__(self, cost_table: Dict[str, TestCost]):
+    def __init__(self, cost_table: Dict[str, CptCost]):
         self.cost_table = {k.lower(): v for k, v in cost_table.items()}
         self.aliases: Dict[str, str] = {}
 
@@ -21,7 +21,7 @@ class CostEstimator:
         The CSV file is expected to contain ``test_name``, ``cpt_code`` and
         ``price`` columns. Rows that are missing data are skipped.
         """
-        table: Dict[str, TestCost] = {}
+        table: Dict[str, CptCost] = {}
         with open(path, newline="", encoding="utf-8") as fh:
             reader = csv.DictReader(fh)
             for row in reader:
@@ -31,10 +31,10 @@ class CostEstimator:
                     price = float(row["price"])
                 except Exception:
                     continue
-                table[name] = TestCost(cpt_code=cpt, price=price)
+                table[name] = CptCost(cpt_code=cpt, price=price)
         return CostEstimator(table)
 
-    def lookup_cost(self, test_name: str) -> Optional[TestCost]:
+    def lookup_cost(self, test_name: str) -> Optional[CptCost]:
         key = test_name.strip().lower()
         if key in self.aliases:
             key = self.aliases[key]

--- a/tests/test_cost_estimator.py
+++ b/tests/test_cost_estimator.py
@@ -1,6 +1,6 @@
 import tempfile
 import csv
-from sdb.cost_estimator import CostEstimator, TestCost
+from sdb.cost_estimator import CostEstimator, CptCost
 
 
 def test_lookup_and_estimate():


### PR DESCRIPTION
## Summary
- rename `TestCost` dataclass to `CptCost`
- update imports and usages across the codebase
- adjust unit test imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869be25e250832a8fb9bb80712546e5