### PR TITLE
Pass case info to panel

### DIFF
--- a/sdb/orchestrator.py
+++ b/sdb/orchestrator.py
@@ -10,7 +10,9 @@ class Orchestrator:
         self.ordered_tests = []
 
     def run_turn(self, case_info: str) -> str:
-        action = self.panel.deliberate(case_info)
+        """Process a single interaction turn with the panel."""
+
+        action = self.panel.deliberate(case_info=case_info)
         xml = build_action(action.action_type, action.content)
         result = self.gatekeeper.answer_question(xml)
 

--- a/sdb/panel.py
+++ b/sdb/panel.py
@@ -8,11 +8,21 @@ class PanelAction:
 
 class VirtualPanel:
     """Simulate collaborative panel of doctors."""
+
     def __init__(self):
         self.turn = 0
+        self.last_case_info = ""
 
     def deliberate(self, case_info: str) -> PanelAction:
-        """Very small demo implementation of the Chain of Debate."""
+        """Very small demo implementation of the Chain of Debate.
+
+        Parameters
+        ----------
+        case_info:
+            Latest information snippet from the gatekeeper.
+        """
+
+        self.last_case_info = case_info
         self.turn += 1
 
         if self.turn == 1:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+from sdb.orchestrator import Orchestrator
+from sdb.panel import VirtualPanel
+
+
+@dataclass
+class DummyResult:
+    content: str
+    synthetic: bool = False
+
+
+class DummyGatekeeper:
+    def answer_question(self, xml: str) -> DummyResult:
+        return DummyResult("ack")
+
+
+def test_run_turn_passes_case_info():
+    panel = VirtualPanel()
+    orch = Orchestrator(panel, DummyGatekeeper())
+    orch.run_turn("snippet")
+    assert panel.last_case_info == "snippet"

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -4,5 +4,16 @@ from sdb.protocol import ActionType
 
 def test_panel_sequence():
     panel = VirtualPanel()
-    actions = [panel.deliberate("").action_type for _ in range(4)]
-    assert actions == [ActionType.QUESTION, ActionType.TEST, ActionType.QUESTION, ActionType.DIAGNOSIS]
+    infos = ["info1", "info2", "info3", "info4"]
+    actions = []
+
+    for info in infos:
+        actions.append(panel.deliberate(info).action_type)
+        assert panel.last_case_info == info
+
+    assert actions == [
+        ActionType.QUESTION,
+        ActionType.TEST,
+        ActionType.QUESTION,
+        ActionType.DIAGNOSIS,
+    ]


### PR DESCRIPTION
## Summary
- track last snippet of case info inside `VirtualPanel`
- send case info to `VirtualPanel.deliberate` from `Orchestrator.run_turn`
- verify that panels receive case info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869beda9e04832abc68e5b8748919be