### PR TITLE
Add orchestrator and evaluator tests

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+from sdb.evaluation import Evaluator
+from sdb.judge import Judgement
+
+
+@dataclass
+class DummyJudge:
+    score: int
+
+    def evaluate(self, diagnosis: str, truth: str) -> Judgement:
+        return Judgement(score=self.score, explanation="")
+
+
+class DummyCostEstimator:
+    def __init__(self, costs):
+        self.costs = costs
+
+    def estimate_cost(self, test_name: str) -> float:
+        return self.costs.get(test_name, 0.0)
+
+
+def test_evaluator_aggregates_score_and_cost():
+    judge = DummyJudge(score=4)
+    coster = DummyCostEstimator({"cbc": 10.0, "bmp": 20.0})
+    ev = Evaluator(judge, coster)
+    result = ev.evaluate("flu", "flu", ["cbc", "bmp"])
+    assert result.score == 4
+    assert result.total_cost == 30.0
+
+
+def test_evaluator_zero_tests_cost():
+    judge = DummyJudge(score=5)
+    coster = DummyCostEstimator({})
+    ev = Evaluator(judge, coster)
+    result = ev.evaluate("x", "x", [])
+    assert result.score == 5
+    assert result.total_cost == 0.0
+

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -20,3 +20,41 @@ def test_run_turn_passes_case_info():
     orch = Orchestrator(panel, DummyGatekeeper())
     orch.run_turn("snippet")
     assert panel.last_case_info == "snippet"
+
+from sdb.panel import PanelAction
+from sdb.protocol import ActionType
+
+
+class StubPanel:
+    """Panel returning a predefined sequence of actions."""
+
+    def __init__(self, actions):
+        self.actions = actions
+        self.index = 0
+        self.last_case_info = ""
+
+    def deliberate(self, case_info: str) -> PanelAction:
+        self.last_case_info = case_info
+        action = self.actions[self.index]
+        self.index += 1
+        return action
+
+
+def test_orchestrator_collects_tests_and_finishes():
+    actions = [
+        PanelAction(ActionType.TEST, "cbc"),
+        PanelAction(ActionType.TEST, "bmp"),
+        PanelAction(ActionType.DIAGNOSIS, "flu"),
+    ]
+    panel = StubPanel(actions)
+    orch = Orchestrator(panel, DummyGatekeeper())
+
+    orch.run_turn("step1")
+    orch.run_turn("step2")
+    assert orch.ordered_tests == ["cbc", "bmp"]
+    assert orch.finished is False
+
+    orch.run_turn("step3")
+    assert orch.finished is True
+    assert orch.ordered_tests == ["cbc", "bmp"]
+


### PR DESCRIPTION
## Summary
- expand orchestrator tests with stubbed panel actions
- add tests covering Evaluator aggregation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c08b3cb8832a8f2375d6bb68858c