### PR TITLE
Add CSV loader for case database

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ directory containing case data and specify the desired case identifier:
 ```bash
 python cli.py --db cases.json --case 1
 ```
+
+## Case database
+
+`CaseDatabase` can load cases from JSON, directories of text files or from
+CSV files. Loading from CSV is convenient when case data is stored in a single
+table:
+
+```python
+from sdb.case_database import CaseDatabase
+db = CaseDatabase.load_from_csv("cases.csv")
+```
+
+The CSV must contain `id`, `summary` and `full_text` columns.

--- a/sdb/case_database.py
+++ b/sdb/case_database.py
@@ -1,7 +1,8 @@
+import csv
 import json
 import os
 from dataclasses import dataclass
-from typing import List, Dict, Iterable
+from typing import Iterable
 
 @dataclass
 class Case:
@@ -30,6 +31,28 @@ class CaseDatabase:
         with open(path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
         cases = [Case(**item) for item in data]
+        return CaseDatabase(cases)
+
+    @staticmethod
+    def load_from_csv(path: str) -> "CaseDatabase":
+        """Load cases from a CSV file.
+
+        The CSV file should contain ``id``, ``summary`` and ``full_text``
+        columns. Rows missing these fields are skipped.
+        """
+        cases = []
+        with open(path, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                try:
+                    case_id = row["id"].strip()
+                    summary = row["summary"].strip()
+                    full_text = row["full_text"].strip()
+                except Exception:
+                    continue
+                if not case_id:
+                    continue
+                cases.append(Case(id=case_id, summary=summary, full_text=full_text))
         return CaseDatabase(cases)
 
     @staticmethod

--- a/tests/test_case_database.py
+++ b/tests/test_case_database.py
@@ -1,0 +1,19 @@
+import csv
+import tempfile
+
+from sdb.case_database import CaseDatabase
+
+
+def test_load_from_csv():
+    rows = [
+        {"id": "1", "summary": "s1", "full_text": "f1"},
+        {"id": "2", "summary": "s2", "full_text": "f2"},
+    ]
+    with tempfile.NamedTemporaryFile("w", newline="", delete=False) as f:
+        writer = csv.DictWriter(f, fieldnames=["id", "summary", "full_text"])
+        writer.writeheader()
+        writer.writerows(rows)
+        path = f.name
+    db = CaseDatabase.load_from_csv(path)
+    assert db.get_case("1").summary == "s1"
+    assert db.get_case("2").full_text == "f2"


### PR DESCRIPTION
## Summary
- support loading cases from CSV
- test CSV case loading
- document CSV feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c4f23fb0832ab6561444e86b3eda