### PR TITLE
Improve Gatekeeper XML parsing and snippet search

### DIFF
--- a/tests/test_gatekeeper.py
+++ b/tests/test_gatekeeper.py
@@ -31,3 +31,17 @@ def test_diagnosis_refusal():
     q = build_action(ActionType.QUESTION, "what is the diagnosis?")
     res = gk.answer_question(q)
     assert res.synthetic is True
+
+
+def test_case_insensitive_search():
+    gk = setup_gatekeeper()
+    q = build_action(ActionType.QUESTION, "COUGH FOR 3 DAYS")
+    res = gk.answer_question(q)
+    assert "cough for 3 days" in res.content.lower()
+    assert res.synthetic is False
+
+
+def test_invalid_xml():
+    gk = setup_gatekeeper()
+    res = gk.answer_question("<question>missing</question")
+    assert res.synthetic is True


### PR DESCRIPTION
## Summary
- replace regex query parsing with `xml.etree.ElementTree`
- use case-insensitive regex search for snippets
- add tests for case insensitive questions and invalid XML

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c704ae88832a96e2f35c235d7c00