### PR TITLE
Add keyword-based heuristics to VirtualPanel

### DIFF
--- a/sdb/panel.py
+++ b/sdb/panel.py
@@ -1,5 +1,9 @@
+"""Virtual panel of doctors using simple rule-based heuristics."""
+
 from dataclasses import dataclass
-from .protocol import ActionType, build_action
+from typing import Dict, List, Optional, Set, Tuple
+
+from .protocol import ActionType
 
 @dataclass
 class PanelAction:
@@ -9,11 +13,28 @@ class PanelAction:
     content: str
 
 class VirtualPanel:
-    """Simulate collaborative panel of doctors."""
+    """Simulate collaborative panel of doctors with simple heuristics."""
 
-    def __init__(self):
+    DEFAULT_KEYWORD_ACTIONS: Dict[str, Tuple[ActionType, str]] = {
+        "cough": (ActionType.TEST, "chest x-ray"),
+    }
+
+    def __init__(self, keyword_actions: Optional[Dict[str, Tuple[ActionType, str]]] = None):
         self.turn = 0
         self.last_case_info = ""
+        self.past_infos: List[str] = []
+        self.keyword_actions = keyword_actions or self.DEFAULT_KEYWORD_ACTIONS
+        self.triggered_keywords: Set[str] = set()
+
+    def _check_keyword_rules(self) -> Optional[PanelAction]:
+        """Return an action if any keyword rule matches accumulated info."""
+
+        text = " ".join(self.past_infos).lower()
+        for keyword, (atype, content) in self.keyword_actions.items():
+            if keyword.lower() in text and keyword not in self.triggered_keywords:
+                self.triggered_keywords.add(keyword)
+                return PanelAction(atype, content)
+        return None
 
     def deliberate(self, case_info: str) -> PanelAction:
         """Very small demo implementation of the Chain of Debate.
@@ -25,12 +46,18 @@ class VirtualPanel:
         """
 
         self.last_case_info = case_info
+        self.past_infos.append(case_info)
         self.turn += 1
 
         if self.turn == 1:
             # Dr. Hypothesis asks for key symptom information
             return PanelAction(ActionType.QUESTION, "chief complaint")
-        elif self.turn == 2:
+
+        action = self._check_keyword_rules()
+        if action:
+            return action
+
+        if self.turn == 2:
             # Test-Chooser orders a basic test
             return PanelAction(ActionType.TEST, "complete blood count")
         elif self.turn == 3:

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -17,3 +17,14 @@ def test_panel_sequence():
         ActionType.QUESTION,
         ActionType.DIAGNOSIS,
     ]
+
+
+def test_keyword_triggers_chest_xray():
+    panel = VirtualPanel()
+    first = panel.deliberate("Patient complains of cough")
+    assert first.action_type == ActionType.QUESTION
+
+    second = panel.deliberate("additional info")
+    assert panel.last_case_info == "additional info"
+    assert second.action_type == ActionType.TEST
+    assert second.content == "chest x-ray"


### PR DESCRIPTION
## Summary
- make VirtualPanel react to past case information
- provide configurable keyword-to-action mapping and default cough rule
- test that cough info results in a chest X-ray order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869cd4f9fc8832abda577ef1a5aee4d