### PR TITLE
Add evaluation step to CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,28 +1,47 @@
 """Command line interface for running a demo diagnostic session."""
 
 import argparse
+import json
 import os
-from sdb import CaseDatabase, Gatekeeper, CostEstimator, VirtualPanel, Orchestrator
-from sdb.cost_estimator import CptCost
+from sdb import (
+    CaseDatabase,
+    Gatekeeper,
+    CostEstimator,
+    VirtualPanel,
+    Orchestrator,
+    Judge,
+    Evaluator,
+)
 
 
 def main() -> None:
     """Run a demo diagnostic session using the virtual panel."""
 
     parser = argparse.ArgumentParser(description="Run a simple diagnostic session")
-    parser.add_argument("--db", required=True, help="Path to case JSON or directory")
+    parser.add_argument("--db", required=True, help="Path to case JSON, CSV or directory")
     parser.add_argument("--case", required=True, help="Case identifier")
+    parser.add_argument("--rubric", required=True, help="Path to scoring rubric JSON")
+    parser.add_argument("--costs", required=True, help="Path to test cost table CSV")
     args = parser.parse_args()
 
     if os.path.isdir(args.db):
         db = CaseDatabase.load_from_directory(args.db)
+    elif args.db.endswith(".csv"):
+        db = CaseDatabase.load_from_csv(args.db)
     else:
         db = CaseDatabase.load_from_json(args.db)
 
     gatekeeper = Gatekeeper(db, args.case)
     gatekeeper.register_test_result("complete blood count", "normal")
 
-    cost_estimator = CostEstimator({"complete blood count": CptCost("100", 10.0)})
+    cost_estimator = CostEstimator.load_from_csv(args.costs)
+
+    with open(args.rubric, "r", encoding="utf-8") as fh:
+        rubric = json.load(fh)
+
+    judge = Judge(rubric)
+    evaluator = Evaluator(judge, cost_estimator)
+
     panel = VirtualPanel()
     orchestrator = Orchestrator(panel, gatekeeper)
 
@@ -31,6 +50,15 @@ def main() -> None:
         response = orchestrator.run_turn("")
         print(f"Turn {turn+1}: {response}")
         turn += 1
+
+    truth = db.get_case(args.case).summary
+    result = evaluator.evaluate(
+        orchestrator.final_diagnosis or "", truth, orchestrator.ordered_tests
+    )
+
+    print(f"Final diagnosis: {orchestrator.final_diagnosis}")
+    print(f"Total cost: ${result.total_cost:.2f}")
+    print(f"Session score: {result.score}")
 
 
 if __name__ == '__main__':

--- a/sdb/orchestrator.py
+++ b/sdb/orchestrator.py
@@ -8,6 +8,7 @@ class Orchestrator:
         self.gatekeeper = gatekeeper
         self.finished = False
         self.ordered_tests = []
+        self.final_diagnosis: str | None = None
 
     def run_turn(self, case_info: str) -> str:
         """Process a single interaction turn with the panel."""
@@ -20,5 +21,6 @@ class Orchestrator:
             self.ordered_tests.append(action.content)
         if action.action_type == ActionType.DIAGNOSIS:
             self.finished = True
+            self.final_diagnosis = action.content
 
         return result.content

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,28 @@
+import json
+import csv
+import subprocess
+import sys
+
+
+def test_cli_outputs_final_results(tmp_path):
+    cases = [{"id": "1", "summary": "viral infection", "full_text": "cough"}]
+    case_file = tmp_path / "cases.json"
+    with open(case_file, "w", encoding="utf-8") as f:
+        json.dump(cases, f)
+
+    rubric_file = tmp_path / "rubric.json"
+    with open(rubric_file, "w", encoding="utf-8") as f:
+        json.dump({}, f)
+
+    cost_file = tmp_path / "costs.csv"
+    with open(cost_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["test_name", "cpt_code", "price"])
+        writer.writeheader()
+        writer.writerow({"test_name": "complete blood count", "cpt_code": "100", "price": "10"})
+
+    cmd = [sys.executable, "cli.py", "--db", str(case_file), "--case", "1", "--rubric", str(rubric_file), "--costs", str(cost_file)]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    assert "Final diagnosis" in result.stdout
+    assert "Total cost" in result.stdout
+    assert "Session score" in result.stdout

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -57,4 +57,5 @@ def test_orchestrator_collects_tests_and_finishes():
     orch.run_turn("step3")
     assert orch.finished is True
     assert orch.ordered_tests == ["cbc", "bmp"]
+    assert orch.final_diagnosis == "flu"
 


### PR DESCRIPTION
## Summary
- update the CLI to load rubric and cost table
- calculate evaluation score and total cost after running
- store final diagnosis in Orchestrator
- test CLI integration and Orchestrator behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d5af7fb4832a89b71f28236f68d3