### PR TITLE
Add init docstrings

### DIFF
--- a/sdb/case_database.py
+++ b/sdb/case_database.py
@@ -18,6 +18,14 @@ class CaseDatabase:
     """Stub for CPC case storage."""
 
     def __init__(self, cases: Iterable[Case]):
+        """Create a database from an iterable of cases.
+
+        Parameters
+        ----------
+        cases:
+            Iterable of :class:`Case` objects to index by their ``id``.
+        """
+
         self.cases = {case.id: case for case in cases}
 
     def get_case(self, case_id: str) -> Case:

--- a/sdb/cost_estimator.py
+++ b/sdb/cost_estimator.py
@@ -16,6 +16,14 @@ class CostEstimator:
     """Map tests to CPT codes and prices."""
 
     def __init__(self, cost_table: Dict[str, CptCost]):
+        """Initialize estimator with a pricing table.
+
+        Parameters
+        ----------
+        cost_table:
+            Mapping of test names to :class:`CptCost` records.
+        """
+
         self.cost_table = {k.lower(): v for k, v in cost_table.items()}
         self.aliases: Dict[str, str] = {}
 

--- a/sdb/gatekeeper.py
+++ b/sdb/gatekeeper.py
@@ -31,6 +31,16 @@ class Gatekeeper:
     """Information oracle mediating access to the case."""
 
     def __init__(self, db: CaseDatabase, case_id: str):
+        """Bind the gatekeeper to a case and set up test cache.
+
+        Parameters
+        ----------
+        db:
+            Database from which to retrieve the case.
+        case_id:
+            Identifier of the case the gatekeeper will manage.
+        """
+
         self.case = db.get_case(case_id)
         self.known_tests: Dict[str, str] = {}
 

--- a/sdb/orchestrator.py
+++ b/sdb/orchestrator.py
@@ -13,6 +13,22 @@ class Orchestrator:
         budget: float | None = None,
         question_only: bool = False,
     ):
+        """Coordinate panel actions and track test spending.
+
+        Parameters
+        ----------
+        panel:
+            :class:`VirtualPanel` generating actions.
+        gatekeeper:
+            Interface used to obtain answers from the case.
+        cost_estimator:
+            Optional :class:`CostEstimator` for test pricing.
+        budget:
+            Optional maximum spend allowed for tests.
+        question_only:
+            If ``True``, convert test requests into questions.
+        """
+
         self.panel = panel
         self.gatekeeper = gatekeeper
         self.cost_estimator = cost_estimator


### PR DESCRIPTION
## Summary
- document the purpose and parameters of `CaseDatabase`, `CostEstimator`, `Gatekeeper`, and `Orchestrator` constructors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a1c276360832aabffae655eddf856