### PR TITLE
Add CSV alias loader for CostEstimator

### DIFF
--- a/sdb/cost_estimator.py
+++ b/sdb/cost_estimator.py
@@ -58,6 +58,24 @@ class CostEstimator:
         for k, v in mapping.items():
             self.aliases[k.lower()] = v.lower()
 
+    def load_aliases_from_csv(self, path: str) -> None:
+        """Load alias mapping from CSV file.
+
+        The CSV should provide ``alias`` and ``canonical`` columns. Rows
+        missing these fields are skipped.
+        """
+        with open(path, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                try:
+                    alias = row["alias"].strip().lower()
+                    canonical = row["canonical"].strip().lower()
+                except Exception:
+                    continue
+                if not alias or not canonical:
+                    continue
+                self.aliases[alias] = canonical
+
     def estimate_cost(self, test_name: str) -> float:
         tc = self.lookup_cost(test_name)
         if tc:

--- a/tests/test_cost_estimator.py
+++ b/tests/test_cost_estimator.py
@@ -22,3 +22,30 @@ def test_lookup_and_estimate():
     assert ce.lookup_cost("basic metabolic panel").cpt_code == "101"
     # Unknown test uses average of known prices => (10+20)/2=15
     assert ce.estimate_cost("unknown") == 15.0
+
+
+def test_load_aliases_from_csv(tmp_path):
+    cost_rows = [
+        {"test_name": "bmp", "cpt_code": "101", "price": "20"},
+    ]
+    cost_path = tmp_path / "cost.csv"
+    with open(cost_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["test_name", "cpt_code", "price"]
+        )
+        writer.writeheader()
+        writer.writerows(cost_rows)
+
+    alias_rows = [
+        {"alias": "basic metabolic panel", "canonical": "bmp"},
+    ]
+    alias_path = tmp_path / "aliases.csv"
+    with open(alias_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["alias", "canonical"])
+        writer.writeheader()
+        writer.writerows(alias_rows)
+
+    ce = CostEstimator.load_from_csv(str(cost_path))
+    ce.load_aliases_from_csv(str(alias_path))
+
+    assert ce.lookup_cost("basic metabolic panel").cpt_code == "101"


### PR DESCRIPTION
## Summary
- add `load_aliases_from_csv` method to `CostEstimator`
- extend cost estimator tests for alias CSV loading

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a1cf65904832aa53a6ef78b94dd9b