### PR TITLE
Add test for unknown XML tag handling

### DIFF
--- a/tests/test_gatekeeper.py
+++ b/tests/test_gatekeeper.py
@@ -84,3 +84,11 @@ def test_mixed_question_and_test_refused():
     query = "<wrapper><question>a</question><test>b</test></wrapper>"
     res = gk.answer_question(query)
     assert res.synthetic is True
+
+
+def test_unknown_xml_tag():
+    """Unrecognized actions should return a synthetic reply."""
+    gk = setup_gatekeeper()
+    res = gk.answer_question("<foo>bar</foo>")
+    assert res.synthetic is True
+    assert res.content == "Unknown action"


### PR DESCRIPTION
## Summary
- add a regression test for requests with unrecognized XML tags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a1e2ab04c832a8af534d1d8e62bcc