### PR TITLE
Add SDBench case conversion tool

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14,6 +14,7 @@ from sdb import (
     Orchestrator,
     Judge,
     Evaluator,
+    convert_directory,
 )
 
 
@@ -25,18 +26,15 @@ def main() -> None:
     )
     parser.add_argument(
         "--db",
-        required=True,
         help="Path to case JSON, CSV or directory",
     )
-    parser.add_argument("--case", required=True, help="Case identifier")
+    parser.add_argument("--case", help="Case identifier")
     parser.add_argument(
         "--rubric",
-        required=True,
         help="Path to scoring rubric JSON",
     )
     parser.add_argument(
         "--costs",
-        required=True,
         help="Path to test cost table CSV",
     )
     parser.add_argument(
@@ -62,6 +60,19 @@ def main() -> None:
         help="Reduce logging noise",
     )
     parser.add_argument(
+        "--convert", action="store_true", help="Convert raw cases to JSON"
+    )
+    parser.add_argument(
+        "--raw-dir",
+        default="data/raw_cases",
+        help="Directory with raw text cases for conversion",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="data/sdbench/cases",
+        help="Destination for converted JSON cases",
+    )
+    parser.add_argument(
 
         "--budget",
         type=float,
@@ -81,6 +92,16 @@ def main() -> None:
         help="Run mode",
     )
     args = parser.parse_args()
+
+    if args.convert:
+        convert_directory(args.raw_dir, args.output_dir)
+        return
+
+    required = [args.db, args.case, args.rubric, args.costs]
+    if any(item is None for item in required):
+        parser.error(
+            "--db, --case, --rubric and --costs are required for a session"
+        )
 
     level = logging.INFO
     if args.verbose:

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -10,6 +10,7 @@ from .panel import VirtualPanel
 from .decision import DecisionEngine, RuleEngine, LLMEngine
 from .orchestrator import Orchestrator
 from .evaluation import Evaluator
+from .ingest.convert import convert_directory
 
 __all__ = [
     "Case",
@@ -27,4 +28,5 @@ __all__ = [
     "VirtualPanel",
     "Orchestrator",
     "Evaluator",
+    "convert_directory",
 ]

--- a/sdb/ingest/convert.py
+++ b/sdb/ingest/convert.py
@@ -1,0 +1,102 @@
+"""Utilities for converting raw case text into SDBench JSON format."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import List, Dict
+
+
+def split_steps(text: str) -> List[str]:
+    """Split raw text into stepwise sections.
+
+    Parameters
+    ----------
+    text:
+        Raw case text.
+
+    Returns
+    -------
+    list of str
+        List of non-empty paragraphs representing sequential steps.
+    """
+
+    parts = re.split(r"\n\s*\n", text.strip())
+    paragraphs = [p.strip() for p in parts if p.strip()]
+    return paragraphs
+
+
+def convert_text(text: str, case_id: int) -> Dict[str, object]:
+    """Convert raw case text to SDBench JSON structure.
+
+    Parameters
+    ----------
+    text:
+        Raw case text.
+    case_id:
+        Sequential case identifier starting at 1.
+
+    Returns
+    -------
+    dict
+        Dictionary ready to be serialized as JSON.
+    """
+
+    steps = split_steps(text)
+    summary = steps[0] if steps else ""
+    data = {
+        "id": f"case_{case_id:03d}",
+        "summary": summary,
+        "steps": [
+            {"id": idx + 1, "text": step} for idx, step in enumerate(steps)
+        ],
+    }
+    return data
+
+
+def convert_directory(src_dir: str, dest_dir: str) -> List[str]:
+    """Convert all ``case_*.txt`` files in ``src_dir`` to JSON files.
+
+    Parameters
+    ----------
+    src_dir:
+        Directory containing raw ``case_###.txt`` files.
+    dest_dir:
+        Output directory for ``case_###.json`` files.
+
+    Returns
+    -------
+    list of str
+        Paths of files written.
+    """
+
+    os.makedirs(dest_dir, exist_ok=True)
+    written: List[str] = []
+    for name in sorted(os.listdir(src_dir)):
+        if not name.startswith("case_") or not name.endswith(".txt"):
+            continue
+        num_part = name[5:-4]
+        try:
+            case_num = int(num_part)
+        except ValueError:
+            continue
+        path = os.path.join(src_dir, name)
+        with open(path, "r", encoding="utf-8") as fh:
+            text = fh.read()
+        data = convert_text(text, case_num)
+        out_path = os.path.join(dest_dir, f"case_{case_num:03d}.json")
+        with open(out_path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+        written.append(out_path)
+    return written
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Convert raw cases to JSON")
+    parser.add_argument("src", help="Directory with raw case text files")
+    parser.add_argument("dest", help="Output directory for JSON cases")
+    args = parser.parse_args()
+    convert_directory(args.src, args.dest)

--- a/tests/test_convert_cases.py
+++ b/tests/test_convert_cases.py
@@ -1,0 +1,39 @@
+import json
+import subprocess
+import sys
+from sdb.ingest.convert import convert_directory
+
+
+def test_convert_directory(tmp_path):
+    raw_dir = tmp_path / "raw"
+    out_dir = tmp_path / "out"
+    raw_dir.mkdir()
+    (raw_dir / "case_001.txt").write_text("Para1\n\nPara2")
+    (raw_dir / "case_002.txt").write_text("First\n\nSecond")
+    written = convert_directory(str(raw_dir), str(out_dir))
+    assert len(written) == 2
+    for idx in [1, 2]:
+        path = out_dir / f"case_{idx:03d}.json"
+        data = json.loads(path.read_text())
+        assert data["id"] == f"case_{idx:03d}"
+        assert len(data["steps"]) == 2
+        assert data["summary"]
+
+
+def test_cli_convert(tmp_path):
+    raw_dir = tmp_path / "raw"
+    out_dir = tmp_path / "out"
+    raw_dir.mkdir()
+    (raw_dir / "case_001.txt").write_text("P1")
+    cmd = [
+        sys.executable,
+        "cli.py",
+        "--convert",
+        "--raw-dir",
+        str(raw_dir),
+        "--output-dir",
+        str(out_dir),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert (out_dir / "case_001.json").exists()


### PR DESCRIPTION
## Summary
- ingest raw case text using `sdb.ingest.convert`
- expose conversion helper from `sdb` package
- add `--convert` mode to CLI to produce SDBench JSON cases
- test conversion utilities and CLI

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a2631033c832a9bb312d22cf29ec0