### PR TITLE
Hold out recent CPC cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ python sdb/ingest/convert.py data/raw_cases data/json_cases
 This command also writes `case_###_summary.txt` files alongside the JSON
 for quick reference.
 
+Cases published in 2024–2025 are automatically placed in
+`data/sdbench/hidden_cases/` during conversion and excluded from the public
+dataset. These 56 recent cases form a held‑out evaluation set selected purely
+by publication year parsed from the case citation.
+
 ### Python API Example
 
 ```python

--- a/cli.py
+++ b/cli.py
@@ -73,6 +73,11 @@ def main() -> None:
         help="Destination for converted JSON cases",
     )
     parser.add_argument(
+        "--hidden-dir",
+        default="data/sdbench/hidden_cases",
+        help="Directory for held-out cases from 2024-2025",
+    )
+    parser.add_argument(
 
         "--budget",
         type=float,
@@ -94,7 +99,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.convert:
-        convert_directory(args.raw_dir, args.output_dir)
+        convert_directory(args.raw_dir, args.output_dir, args.hidden_dir)
         return
 
     required = [args.db, args.case, args.rubric, args.costs]

--- a/tasks.yml
+++ b/tasks.yml
@@ -166,6 +166,7 @@ phases:
       - id: 4
         title: "Create hidden test set"
         description: "Hold out 56 recent cases from 2024\u20132025 as a hidden evaluation set."
+        done: true
       - id: 5
         title: "Lookup CPT codes with language model"
         description: "Translate test requests into CPT codes using an LLM."

--- a/tests/test_convert_cases.py
+++ b/tests/test_convert_cases.py
@@ -7,26 +7,29 @@ from sdb.ingest.convert import convert_directory
 def test_convert_directory(tmp_path):
     raw_dir = tmp_path / "raw"
     out_dir = tmp_path / "out"
+    hidden_dir = tmp_path / "hidden"
     raw_dir.mkdir()
-    (raw_dir / "case_001.txt").write_text("Para1\n\nPara2")
-    (raw_dir / "case_002.txt").write_text("First\n\nSecond")
-    written = convert_directory(str(raw_dir), str(out_dir))
-    assert len(written) == 2
-    for idx in [1, 2]:
-        path = out_dir / f"case_{idx:03d}.json"
-        data = json.loads(path.read_text())
-        assert data["id"] == f"case_{idx:03d}"
-        assert len(data["steps"]) == 2
-        assert data["summary"]
-        summary_file = out_dir / f"case_{idx:03d}_summary.txt"
-        assert summary_file.exists()
+    (raw_dir / "case_001.txt").write_text("N Engl J Med. 2025 Jan;\n\nPara2")
+    (raw_dir / "case_002.txt").write_text("N Engl J Med. 2023 Jan;\n\nSecond")
+    written = convert_directory(str(raw_dir), str(out_dir), str(hidden_dir))
+    assert len(written) == 1
+    path = out_dir / "case_002.json"
+    data = json.loads(path.read_text())
+    assert data["id"] == "case_002"
+    assert len(data["steps"]) == 2
+    assert data["summary"]
+    summary_file = out_dir / "case_002_summary.txt"
+    assert summary_file.exists()
+    assert (hidden_dir / "case_001.json").exists()
+    assert (hidden_dir / "case_001_summary.txt").exists()
 
 
 def test_cli_convert(tmp_path):
     raw_dir = tmp_path / "raw"
     out_dir = tmp_path / "out"
+    hidden_dir = tmp_path / "hidden"
     raw_dir.mkdir()
-    (raw_dir / "case_001.txt").write_text("P1")
+    (raw_dir / "case_001.txt").write_text("P1 2025\n")
     cmd = [
         sys.executable,
         "cli.py",
@@ -35,8 +38,10 @@ def test_cli_convert(tmp_path):
         str(raw_dir),
         "--output-dir",
         str(out_dir),
+        "--hidden-dir",
+        str(hidden_dir),
     ]
     result = subprocess.run(cmd, capture_output=True, text=True)
     assert result.returncode == 0
-    assert (out_dir / "case_001.json").exists()
-    assert (out_dir / "case_001_summary.txt").exists()
+    assert (hidden_dir / "case_001.json").exists()
+    assert (hidden_dir / "case_001_summary.txt").exists()


### PR DESCRIPTION
## Summary
- split 2024-2025 cases into a hidden evaluation directory
- expose `--hidden-dir` to CLI
- update ingestion docs and tasks roadmap
- test holdout logic

## Testing
- `pip install requests`
- `pip install flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a2f1dcd70832a9d6dcc036f24c556