### PR TITLE
Implement CPT lookup utility with LLM caching

### DIFF
--- a/data/cpt_lookup.csv
+++ b/data/cpt_lookup.csv
@@ -1,0 +1,1 @@
+test_name,cpt_code

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -11,6 +11,7 @@ from .decision import DecisionEngine, RuleEngine, LLMEngine
 from .orchestrator import Orchestrator
 from .evaluation import Evaluator
 from .ingest.convert import convert_directory
+from .cpt_lookup import lookup_cpt
 
 __all__ = [
     "Case",
@@ -29,4 +30,5 @@ __all__ = [
     "Orchestrator",
     "Evaluator",
     "convert_directory",
+    "lookup_cpt",
 ]

--- a/sdb/cpt_lookup.py
+++ b/sdb/cpt_lookup.py
@@ -1,0 +1,89 @@
+"""Utilities for mapping free-text test names to CPT codes via LLM."""
+
+from __future__ import annotations
+
+import csv
+import os
+import time
+from typing import Dict, Optional
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - openai not required for tests
+    openai = None
+
+
+DEFAULT_CACHE = os.path.join("data", "cpt_lookup.csv")
+
+
+def _load_cache(path: str) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    if not os.path.exists(path):
+        return mapping
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            try:
+                name = row["test_name"].strip().lower()
+                code = row["cpt_code"].strip()
+            except Exception:
+                continue
+            if name and code:
+                mapping[name] = code
+    return mapping
+
+
+def _append_cache(path: str, test_name: str, cpt_code: str) -> None:
+    exists = os.path.exists(path)
+    with open(path, "a", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["test_name", "cpt_code"])
+        if not exists:
+            writer.writeheader()
+        writer.writerow({"test_name": test_name, "cpt_code": cpt_code})
+
+
+def _query_llm(test_name: str, retries: int = 3) -> Optional[str]:
+    if openai is None:
+        return None
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+    openai.api_key = api_key
+    model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "Return only the CPT code that matches "
+                "the diagnostic test name."
+            ),
+        },
+        {"role": "user", "content": test_name},
+    ]
+    for _ in range(retries):
+        try:
+            resp = openai.ChatCompletion.create(
+                model=model,
+                messages=messages,
+                max_tokens=10,
+            )
+            return resp.choices[0].message["content"].strip().split()[0]
+        except Exception:  # pragma: no cover - network issues
+            time.sleep(1)
+    return None
+
+
+def lookup_cpt(
+    test_name: str, cache_path: str = DEFAULT_CACHE
+) -> Optional[str]:
+    """Return the CPT code for ``test_name`` using cache or LLM lookup."""
+
+    key = test_name.strip().lower()
+    cache = _load_cache(cache_path)
+    if key in cache:
+        return cache[key]
+
+    code = _query_llm(test_name)
+    if code:
+        _append_cache(cache_path, key, code)
+    return code

--- a/tests/test_cpt_lookup.py
+++ b/tests/test_cpt_lookup.py
@@ -1,0 +1,35 @@
+import csv
+from types import SimpleNamespace
+from sdb.cpt_lookup import lookup_cpt
+
+
+def test_cache_hit(tmp_path):
+    cache = tmp_path / "cache.csv"
+    with open(cache, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["test_name", "cpt_code"])
+        writer.writeheader()
+        writer.writerow({"test_name": "cbc", "cpt_code": "85027"})
+    assert lookup_cpt("cbc", cache_path=str(cache)) == "85027"
+
+
+def test_llm_lookup_and_cache(tmp_path, monkeypatch):
+    cache = tmp_path / "cache.csv"
+
+    def fake_create(model, messages, max_tokens):
+        choice = SimpleNamespace(message={"content": "12345"})
+        return SimpleNamespace(choices=[choice])
+
+    dummy_openai = SimpleNamespace(
+        ChatCompletion=SimpleNamespace(create=fake_create),
+        api_key=None,
+    )
+    import sdb.cpt_lookup as cl
+
+    monkeypatch.setattr(cl, "openai", dummy_openai)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+
+    code = cl.lookup_cpt("bmp", cache_path=str(cache))
+    assert code == "12345"
+    with open(cache, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["cpt_code"] == "12345"


### PR DESCRIPTION
## Summary
- add `sdb/cpt_lookup.py` for converting free text test names to CPT codes
- cache CPT lookups in `data/cpt_lookup.csv`
- expose `lookup_cpt` via package `__init__`
- unit tests for caching and LLM query

## Testing
- `flake8 sdb/cpt_lookup.py tests/test_cpt_lookup.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a3084b894832a99a176e1afceeb4d