### PR TITLE
Add per visit fee

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -158,7 +158,10 @@ def main() -> None:
 
     truth = db.get_case(args.case).summary
     result = evaluator.evaluate(
-        orchestrator.final_diagnosis or "", truth, orchestrator.ordered_tests
+        orchestrator.final_diagnosis or "",
+        truth,
+        orchestrator.ordered_tests,
+        visits=turn,
     )
 
     print(f"Final diagnosis: {orchestrator.final_diagnosis}")

--- a/sdb/evaluation.py
+++ b/sdb/evaluation.py
@@ -36,11 +36,27 @@ class Evaluator:
         self.judge = judge
         self.cost_estimator = cost_estimator
 
+    VISIT_FEE = 300.0
+
     def evaluate(
-        self, diagnosis: str, truth: str, tests: list[str]
+        self, diagnosis: str, truth: str, tests: list[str], visits: int = 1
     ) -> SessionResult:
+        """Evaluate a diagnosis and compute total session cost.
+
+        Parameters
+        ----------
+        diagnosis:
+            Final diagnosis proposed by the panel.
+        truth:
+            Ground truth summary used by the judge.
+        tests:
+            List of ordered test names.
+        visits:
+            Number of physician visits that occurred during the session.
+        """
+
         judgement = self.judge.evaluate(diagnosis, truth)
-        total_cost = sum(
+        total_cost = visits * self.VISIT_FEE + sum(
             self.cost_estimator.estimate_cost(t) for t in tests
         )
         return SessionResult(total_cost=total_cost, score=judgement.score)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -24,15 +24,15 @@ def test_evaluator_aggregates_score_and_cost():
     judge = DummyJudge(score=4)
     coster = DummyCostEstimator({"cbc": 10.0, "bmp": 20.0})
     ev = Evaluator(judge, coster)
-    result = ev.evaluate("flu", "flu", ["cbc", "bmp"])
+    result = ev.evaluate("flu", "flu", ["cbc", "bmp"], visits=2)
     assert result.score == 4
-    assert result.total_cost == 30.0
+    assert result.total_cost == 630.0
 
 
 def test_evaluator_zero_tests_cost():
     judge = DummyJudge(score=5)
     coster = DummyCostEstimator({})
     ev = Evaluator(judge, coster)
-    result = ev.evaluate("x", "x", [])
+    result = ev.evaluate("x", "x", [], visits=3)
     assert result.score == 5
-    assert result.total_cost == 0.0
+    assert result.total_cost == 900.0


### PR DESCRIPTION
## Summary
- charge a $300 fee for every physician visit
- pass visit count from the CLI into the evaluator
- update evaluator tests for the new fee logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a34acbd64832ab456918d24f9c4df