### PR TITLE
Enable configurable correctness threshold

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -38,6 +38,12 @@ def main() -> None:
         help="Path to test cost table CSV",
     )
     parser.add_argument(
+        "--correct-threshold",
+        type=int,
+        default=4,
+        help="Judge score required for a correct diagnosis",
+    )
+    parser.add_argument(
         "--panel-engine",
         choices=["rule", "llm"],
         default="rule",
@@ -131,7 +137,11 @@ def main() -> None:
         rubric = json.load(fh)
 
     judge = Judge(rubric)
-    evaluator = Evaluator(judge, cost_estimator)
+    evaluator = Evaluator(
+        judge,
+        cost_estimator,
+        correct_threshold=args.correct_threshold,
+    )
 
     if args.panel_engine == "rule":
         engine = RuleEngine()
@@ -167,6 +177,7 @@ def main() -> None:
     print(f"Final diagnosis: {orchestrator.final_diagnosis}")
     print(f"Total cost: ${result.total_cost:.2f}")
     print(f"Session score: {result.score}")
+    print(f"Correct diagnosis: {result.correct}")
 
 
 if __name__ == "__main__":

--- a/sdb/evaluation.py
+++ b/sdb/evaluation.py
@@ -13,16 +13,25 @@ class SessionResult:
         Sum of test costs incurred during the session.
     score:
         Judgement score for the final diagnosis.
+    correct:
+        Whether the diagnosis is considered correct.
     """
 
     total_cost: float
     score: int
+    correct: bool
 
 
 class Evaluator:
     """Score diagnoses and tally the cost of ordered tests."""
 
-    def __init__(self, judge: Judge, cost_estimator: CostEstimator):
+    def __init__(
+        self,
+        judge: Judge,
+        cost_estimator: CostEstimator,
+        *,
+        correct_threshold: int = 4,
+    ) -> None:
         """Create an evaluator with a judge and cost estimator.
 
         Parameters
@@ -31,10 +40,13 @@ class Evaluator:
             :class:`Judge` instance used to grade diagnoses.
         cost_estimator:
             :class:`CostEstimator` used to compute the price of tests.
+        correct_threshold:
+            Minimum score that constitutes a correct diagnosis.
         """
 
         self.judge = judge
         self.cost_estimator = cost_estimator
+        self.correct_threshold = int(correct_threshold)
 
     VISIT_FEE = 300.0
 
@@ -59,4 +71,9 @@ class Evaluator:
         total_cost = visits * self.VISIT_FEE + sum(
             self.cost_estimator.estimate_cost(t) for t in tests
         )
-        return SessionResult(total_cost=total_cost, score=judgement.score)
+        correct = judgement.score >= self.correct_threshold
+        return SessionResult(
+            total_cost=total_cost,
+            score=judgement.score,
+            correct=correct,
+        )

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -26,6 +26,7 @@ def test_evaluator_aggregates_score_and_cost():
     ev = Evaluator(judge, coster)
     result = ev.evaluate("flu", "flu", ["cbc", "bmp"], visits=2)
     assert result.score == 4
+    assert result.correct
     assert result.total_cost == 630.0
 
 
@@ -35,4 +36,29 @@ def test_evaluator_zero_tests_cost():
     ev = Evaluator(judge, coster)
     result = ev.evaluate("x", "x", [], visits=3)
     assert result.score == 5
+    assert result.correct
     assert result.total_cost == 900.0
+
+
+def test_evaluator_correctness_threshold_default():
+    judge = DummyJudge(score=3)
+    coster = DummyCostEstimator({})
+    ev = Evaluator(judge, coster)
+    result = ev.evaluate("x", "x", [])
+    assert not result.correct
+    judge2 = DummyJudge(score=4)
+    ev2 = Evaluator(judge2, coster)
+    result2 = ev2.evaluate("x", "x", [])
+    assert result2.correct
+
+
+def test_evaluator_correctness_threshold_custom():
+    judge = DummyJudge(score=3)
+    coster = DummyCostEstimator({})
+    ev = Evaluator(judge, coster, correct_threshold=3)
+    result = ev.evaluate("x", "x", [])
+    assert result.correct
+    judge2 = DummyJudge(score=2)
+    ev2 = Evaluator(judge2, coster, correct_threshold=3)
+    result2 = ev2.evaluate("x", "x", [])
+    assert not result2.correct


### PR DESCRIPTION
## Summary
- flag answers as correct when judge score meets a configurable threshold
- expose `--correct-threshold` CLI option
- show correctness in CLI output
- test evaluation correctness for default and custom thresholds

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a35b6e148832abd230bc67a923a98