### PR TITLE
Add pre-commit workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
       - name: Run tests
         run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.9.0
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to Dx0
+
+Thank you for wanting to contribute! This project uses several development tools managed via `pre-commit`.
+
+## Setup
+
+1. Create a Python virtual environment and activate it.
+2. Install development dependencies:
+
+   ```bash
+   pip install -r requirements-dev.txt
+   ```
+
+3. Install the pre-commit hooks so they run automatically on each commit:
+
+   ```bash
+   pre-commit install
+   ```
+
+## Development workflow
+
+- Run `pre-commit run --all-files` to format and lint the code.
+- Execute the unit tests with:
+
+  ```bash
+  pytest -q
+  ```
+
+All tests should pass before submitting a pull request.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,7 @@ flake8
 pytest
 requests
 beautifulsoup4
+black
+isort
+mypy
+pre-commit


### PR DESCRIPTION
## Summary
- add pre-commit configuration for black, isort, flake8 and mypy
- track dev tooling in requirements
- run pre-commit in CI workflow
- explain setup steps in CONTRIBUTING

## Testing
- `pre-commit run --files requirements-dev.txt .pre-commit-config.yaml .github/workflows/ci.yml CONTRIBUTING.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a39046e70832aa51d96a583db703b