### PR TITLE
Add edge case tests and JSON error handling

### DIFF
--- a/sdb/gatekeeper.py
+++ b/sdb/gatekeeper.py
@@ -49,8 +49,11 @@ class Gatekeeper:
 
         if not os.path.exists(path):
             return
-        with open(path, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except json.JSONDecodeError:
+            return
         for name, result in data.items():
             self.register_test_result(name, str(result))
 


### PR DESCRIPTION
## Summary
- handle malformed JSON fixtures in `Gatekeeper`
- expand `gatekeeper` tests for invalid JSON and nested XML
- expand `orchestrator` tests to check timeout propagation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a39d286dc832ab833d1356cfcd5e1