### PR TITLE
Add simple semantic retrieval to Gatekeeper

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -56,6 +56,20 @@ def main() -> None:
         default="gpt-4",
         help="Model name for LLM engine",
     )
+    semantic = parser.add_mutually_exclusive_group()
+    semantic.add_argument(
+        "--semantic-retrieval",
+        dest="semantic",
+        action="store_true",
+        help="Enable semantic retrieval for Gatekeeper",
+    )
+    semantic.add_argument(
+        "--no-semantic-retrieval",
+        dest="semantic",
+        action="store_false",
+        help="Disable semantic retrieval for Gatekeeper",
+    )
+    parser.set_defaults(semantic=False)
     parser.add_argument(
         "--verbose",
         action="store_true",
@@ -136,7 +150,11 @@ def main() -> None:
     else:
         db = CaseDatabase.load_from_json(args.db)
 
-    gatekeeper = Gatekeeper(db, args.case)
+    gatekeeper = Gatekeeper(
+        db,
+        args.case,
+        use_semantic_retrieval=args.semantic,
+    )
     gatekeeper.register_test_result("complete blood count", "normal")
 
     cost_estimator = CostEstimator.load_from_csv(args.costs)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,5 @@ isort
 mypy
 pre-commit
 prometheus_client
+numpy>=1.26.4
 

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -14,6 +14,7 @@ from .ingest.convert import convert_directory
 from .ingest.pipeline import run_pipeline
 from .cpt_lookup import lookup_cpt
 from .metrics import start_metrics_server
+from .retrieval import SimpleEmbeddingIndex
 
 __all__ = [
     "Case",
@@ -35,4 +36,5 @@ __all__ = [
     "lookup_cpt",
     "run_pipeline",
     "start_metrics_server",
+    "SimpleEmbeddingIndex",
 ]

--- a/sdb/retrieval.py
+++ b/sdb/retrieval.py
@@ -1,0 +1,48 @@
+import re
+from typing import List, Tuple
+import numpy as np
+
+
+def _tokenize(text: str) -> List[str]:
+    """Simple whitespace and punctuation tokenizer."""
+    return re.findall(r"\b\w+\b", text.lower())
+
+
+class SimpleEmbeddingIndex:
+    """Naive embedding index backed by NumPy vectors."""
+
+    def __init__(self, documents: List[str]):
+        self.documents = documents
+        tokens_list = [_tokenize(doc) for doc in documents]
+        vocab = sorted({tok for tokens in tokens_list for tok in tokens})
+        self.vocab = {tok: i for i, tok in enumerate(vocab)}
+        self.embeddings = np.zeros(
+            (len(documents), len(self.vocab)), dtype=float
+        )
+        for i, tokens in enumerate(tokens_list):
+            for tok in tokens:
+                idx = self.vocab[tok]
+                self.embeddings[i, idx] += 1.0
+        norms = np.linalg.norm(self.embeddings, axis=1, keepdims=True)
+        self.embeddings = self.embeddings / np.maximum(norms, 1e-8)
+
+    def query(self, text: str, top_k: int = 1) -> List[Tuple[str, float]]:
+        """Return top matching documents and similarity scores."""
+        qvec = np.zeros(len(self.vocab), dtype=float)
+        for tok in _tokenize(text):
+            idx = self.vocab.get(tok)
+            if idx is not None:
+                qvec[idx] += 1.0
+        norm = np.linalg.norm(qvec)
+        if norm == 0:
+            return []
+        qvec /= norm
+        scores = self.embeddings.dot(qvec)
+        if scores.size == 0:
+            return []
+        indices = np.argsort(scores)[::-1][:top_k]
+        results = []
+        for i in indices:
+            if scores[i] > 0:
+                results.append((self.documents[i], float(scores[i])))
+        return results

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,6 +91,7 @@ def test_cli_flag_parsing(tmp_path):
         "--llm-model",
         "turbo",
         "--quiet",
+        "--semantic-retrieval",
     ]
     result = subprocess.run(cmd, capture_output=True, text=True)
     assert result.returncode == 0

--- a/tests/test_gatekeeper.py
+++ b/tests/test_gatekeeper.py
@@ -5,14 +5,14 @@ from sdb.gatekeeper import Gatekeeper
 from sdb.protocol import build_action, ActionType
 
 
-def setup_gatekeeper():
+def setup_gatekeeper(semantic: bool = False):
     case = Case(
         id="1",
         summary="Patient complains of cough",
         full_text="History: patient has had a cough for 3 days.",
     )
     db = CaseDatabase([case])
-    gk = Gatekeeper(db, "1")
+    gk = Gatekeeper(db, "1", use_semantic_retrieval=semantic)
     gk.register_test_result("complete blood count", "normal")
     return gk
 
@@ -70,6 +70,14 @@ def test_case_insensitive_search():
     q = build_action(ActionType.QUESTION, "COUGH FOR 3 DAYS")
     res = gk.answer_question(q)
     assert "cough for 3 days" in res.content.lower()
+    assert res.synthetic is False
+
+
+def test_semantic_retrieval_enabled():
+    gk = setup_gatekeeper(semantic=True)
+    q = build_action(ActionType.QUESTION, "cough")
+    res = gk.answer_question(q)
+    assert "cough" in res.content.lower()
     assert res.synthetic is False
 
 

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,9 @@
+from sdb.retrieval import SimpleEmbeddingIndex
+
+
+def test_simple_embedding_index_returns_match():
+    docs = ["patient has a cough", "chest pain"]
+    index = SimpleEmbeddingIndex(docs)
+    results = index.query("cough")
+    assert results
+    assert results[0][0] == "patient has a cough"


### PR DESCRIPTION
## Summary
- implement `SimpleEmbeddingIndex` using a small numpy-based embedding index
- allow `Gatekeeper` to use semantic retrieval before falling back to regex
- expose new CLI flags to toggle semantic retrieval
- test retrieval logic and update Gatekeeper and CLI tests
- document numpy dependency

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a407f2144832a997fdaced7b3a5d5