### PR TITLE
Add Docker container build and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,22 @@ jobs:
         run: pre-commit run --show-diff-on-failure --color=always --all-files
       - name: Run tests
         run: pytest -q
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim AS builder
+WORKDIR /app
+COPY requirements-dev.txt ./
+RUN pip install --no-cache-dir -r requirements-dev.txt
+COPY . .
+RUN pip install --no-cache-dir -e .
+RUN pytest -q
+
+FROM python:3.11-slim
+WORKDIR /app
+COPY --from=builder /usr/local /usr/local
+COPY --from=builder /app /app
+CMD ["python", "cli.py", "--help"]

--- a/tasks.yml
+++ b/tasks.yml
@@ -65,6 +65,7 @@ phases:
           Add GitHub Actions workflows for tests and releases and create a
           Dockerfile for deployment.
         labels: [ci, docker, devops]
+        done: true
       - id: "T10"
         title: "Update tasks.yml with Engineering Backlog"
         description: >


### PR DESCRIPTION
## Summary
- add Dockerfile with test stage
- build and publish image in CI
- add optional release workflow to push tagged images
- mark CI/CD task as done in roadmap

## Testing
- `pre-commit run --show-diff-on-failure --files .github/workflows/ci.yml .github/workflows/release.yml Dockerfile tasks.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a4284bcbc832a85d97e9241c57319