### PR TITLE
Add basic FastAPI UI for physicians

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ python -m sdb.ingest.pipeline
 ```
 
 
+### Physician UI
+
+Start the demo web interface to chat with the Gatekeeper and view
+running cost estimates:
+
+```bash
+uvicorn sdb.ui.app:app --reload
+```
+
+Then open `http://localhost:8000` in your browser.
+
+
 ### Python API Example
 
 ```python

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,13 @@ The `grafana-dashboard.json` file contains a minimal dashboard displaying
 metrics exported by the MAI-DxO demo. Import it into Grafana to visualize
 `panel_actions_total` and `orchestrator_turns_total` counters collected by
 Prometheus.
+
+## Running the Physician UI
+
+Launch the FastAPI server with:
+
+```bash
+uvicorn sdb.ui.app:app --reload
+```
+
+Visit `http://localhost:8000` to open the chat interface.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,6 @@ mypy
 pre-commit
 prometheus_client
 numpy>=1.26.4
+fastapi
+uvicorn
 

--- a/sdb/ui/__init__.py
+++ b/sdb/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Web UI for interacting with the Gatekeeper."""

--- a/sdb/ui/app.py
+++ b/sdb/ui/app.py
@@ -1,0 +1,121 @@
+"""FastAPI server for chatting with the Gatekeeper."""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import FastAPI, WebSocket
+from fastapi.responses import HTMLResponse
+from starlette.websockets import WebSocketDisconnect
+
+from sdb.case_database import Case, CaseDatabase
+from sdb.cost_estimator import CostEstimator, CptCost
+from sdb.gatekeeper import Gatekeeper
+from sdb.protocol import ActionType, build_action
+
+app = FastAPI(title="SDBench Physician UI")
+
+# Load a small demo case database and cost table
+demo_case = CaseDatabase(
+    [
+        Case(
+            id="demo",
+            summary="A 30 year old with cough",
+            full_text="Patient presents with cough and fever for three days.",
+        )
+    ]
+)
+
+gatekeeper = Gatekeeper(demo_case, "demo")
+
+# Example cost table with a few common labs
+cost_table = {
+    "complete blood count": CptCost(cpt_code="100", price=10.0),
+    "basic metabolic panel": CptCost(cpt_code="101", price=20.0),
+}
+
+cost_estimator = CostEstimator(cost_table)
+spent: float = 0.0
+
+HTML = """
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8'/>
+<title>SDBench Physician UI</title>
+</head>
+<body>
+<h2>SDBench Physician Chat</h2>
+<div id='log'></div>
+<input id='msg' size='80'/>
+<button onclick='send()'>Send</button>
+<script>
+const log = document.getElementById('log');
+const ws = new WebSocket(`ws://${location.host}/ws`);
+ws.onmessage = (e) => {
+  const data = JSON.parse(e.data);
+  log.innerHTML += '<div><b>Gatekeeper:</b> ' +
+    data.reply + ' (Total cost: $' + data.total_spent.toFixed(2) + ')</div>';
+};
+function send() {
+  const v = document.getElementById('msg').value;
+  log.innerHTML += `<div><b>You:</b> ${v}</div>`;
+  let action = 'question';
+  let content = v;
+  if (v.toLowerCase().startsWith('test:')) {
+    action = 'test';
+    content = v.slice(5).trim();
+  }
+  ws.send(JSON.stringify({action: action, content: content}));
+  document.getElementById('msg').value = '';
+}
+</script>
+</body>
+</html>
+"""
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index() -> HTMLResponse:
+    """Return simple chat page."""
+    return HTMLResponse(HTML)
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket) -> None:
+    """Handle websocket interactions with the physician."""
+
+    await ws.accept()
+    global spent
+    try:
+        while True:
+            data = await ws.receive_json()
+            action = data.get("action", "question").lower()
+            content = data.get("content", "")
+            if action == "test":
+                xml = build_action(ActionType.TEST, content)
+                result = gatekeeper.answer_question(xml)
+                cost = cost_estimator.estimate_cost(content)
+                spent += cost
+                await ws.send_json(
+                    {
+                        "reply": result.content,
+                        "synthetic": result.synthetic,
+                        "cost": cost,
+                        "total_spent": spent,
+                    }
+                )
+            else:
+                xml = build_action(ActionType.QUESTION, content)
+                result = gatekeeper.answer_question(xml)
+                await ws.send_json(
+                    {
+                        "reply": result.content,
+                        "synthetic": result.synthetic,
+                        "cost": 0.0,
+                        "total_spent": spent,
+                    }
+                )
+            await asyncio.sleep(0)
+    except WebSocketDisconnect:
+        return

--- a/tasks.yml
+++ b/tasks.yml
@@ -120,6 +120,7 @@ phases:
           Provide a synchronous chat interface for physicians interacting with
           the Gatekeeper and Cost Estimator.
         labels: [feature, frontend, ux]
+        done: true
       - id: "T18"
         title: "Implement Evaluation Pipeline & Reporting"
         description: >

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,16 @@
+from starlette.testclient import TestClient
+
+from sdb.ui.app import app
+
+
+def test_websocket_chat():
+    client = TestClient(app)
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json({"action": "question", "content": "cough"})
+        data = ws.receive_json()
+        assert "reply" in data
+        assert data["total_spent"] == 0.0
+        ws.send_json({"action": "test", "content": "complete blood count"})
+        data = ws.receive_json()
+        assert data["cost"] == 10.0
+        assert data["total_spent"] == 10.0


### PR DESCRIPTION
## Summary
- add FastAPI-based web server under `sdb/ui/`
- expose simple websocket chat and running cost totals
- document how to launch the UI in README and docs
- add dependencies for FastAPI/uvicorn
- update engineering task list and add tests for UI

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a45609878832ab19345c38a1d432a