### PR TITLE
Automate ingestion of new CPC cases

### DIFF
--- a/.github/workflows/update_cases.yml
+++ b/.github/workflows/update_cases.yml
@@ -1,0 +1,33 @@
+name: Update CPC Cases
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Update dataset
+        run: python scripts/update_cases.py
+      - name: Commit changes
+        run: |
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@github.com'
+          git add data/raw_cases data/sdbench/cases data/sdbench/hidden_cases
+          if git diff --cached --quiet; then
+            echo "No updates" && exit 0
+          fi
+          git commit -m 'chore: update CPC cases'
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ refresh the dataset or fetch updates, run the ingestion pipeline:
 python -m sdb.ingest.pipeline
 ```
 
+To append newly released cases without re-downloading the entire corpus, run:
+
+```bash
+python scripts/update_cases.py
+```
+
 
 ### Physician UI
 

--- a/scripts/update_cases.py
+++ b/scripts/update_cases.py
@@ -1,0 +1,36 @@
+"""Fetch newly published NEJM CPC cases and append them to the dataset."""
+
+from __future__ import annotations
+
+import argparse
+
+from sdb.ingest.pipeline import update_dataset
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Update CPC dataset")
+    parser.add_argument(
+        "--raw-dir",
+        default="data/raw_cases",
+        help="Directory for raw case text",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="data/sdbench/cases",
+        help="Destination directory for JSON cases",
+    )
+    parser.add_argument(
+        "--hidden-dir",
+        default="data/sdbench/hidden_cases",
+        help="Directory for held-out cases",
+    )
+    parsed = parser.parse_args(args)
+    update_dataset(
+        raw_dir=parsed.raw_dir,
+        output_dir=parsed.output_dir,
+        hidden_dir=parsed.hidden_dir,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -11,7 +11,7 @@ from .decision import DecisionEngine, RuleEngine, LLMEngine
 from .orchestrator import Orchestrator
 from .evaluation import Evaluator
 from .ingest.convert import convert_directory
-from .ingest.pipeline import run_pipeline
+from .ingest.pipeline import run_pipeline, update_dataset
 from .cpt_lookup import lookup_cpt
 from .metrics import start_metrics_server
 from .retrieval import SimpleEmbeddingIndex
@@ -36,6 +36,7 @@ __all__ = [
     "convert_directory",
     "lookup_cpt",
     "run_pipeline",
+    "update_dataset",
     "start_metrics_server",
     "SimpleEmbeddingIndex",
     "load_scores",

--- a/sdb/ingest/pipeline.py
+++ b/sdb/ingest/pipeline.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import re
-from typing import List
+from typing import List, Set
 
 try:
     import requests
@@ -78,6 +78,66 @@ def collect_cases(
     return paths
 
 
+PMID_RE = re.compile(r"PMID:\s*(\d+)")
+
+
+def _existing_pmids(raw_dir: str) -> Set[str]:
+    """Return PMIDs already present in ``raw_dir``."""
+
+    pmids: Set[str] = set()
+    if not os.path.isdir(raw_dir):
+        return pmids
+    for name in os.listdir(raw_dir):
+        if not name.startswith("case_") or not name.endswith(".txt"):
+            continue
+        path = os.path.join(raw_dir, name)
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                match = PMID_RE.search(fh.read())
+                if match:
+                    pmids.add(match.group(1))
+        except OSError:  # pragma: no cover - file access issues
+            continue
+    return pmids
+
+
+def _next_case_id(raw_dir: str) -> int:
+    """Return the next sequential case identifier."""
+
+    highest = 0
+    if not os.path.isdir(raw_dir):
+        return 1
+    for name in os.listdir(raw_dir):
+        if name.startswith("case_") and name.endswith(".txt"):
+            try:
+                num = int(name[5:-4])
+            except ValueError:
+                continue
+            highest = max(highest, num)
+    return highest + 1
+
+
+def collect_new_cases(dest_dir: str = "data/raw_cases") -> List[str]:
+    """Download only new CPC cases into ``dest_dir``."""
+
+    existing = _existing_pmids(dest_dir)
+    next_id = _next_case_id(dest_dir)
+    pmids = fetch_case_pmids(count=1000)
+    paths = []
+    for pmid in pmids:
+        if pmid in existing:
+            continue
+        try:
+            text = fetch_case_text(pmid)
+        except Exception as exc:  # pragma: no cover - network errors
+            print(f"Failed to fetch PMID {pmid}: {exc}")
+            continue
+        path = save_case_text(next_id, text, dest_dir)
+        next_id += 1
+        paths.append(path)
+    return paths
+
+
 def run_pipeline(
     *,
     raw_dir: str = "data/raw_cases",
@@ -88,6 +148,18 @@ def run_pipeline(
     """Run the full ingestion pipeline."""
     if fetch:
         collect_cases(raw_dir)
+    return convert_directory(raw_dir, output_dir, hidden_dir)
+
+
+def update_dataset(
+    *,
+    raw_dir: str = "data/raw_cases",
+    output_dir: str = "data/sdbench/cases",
+    hidden_dir: str | None = "data/sdbench/hidden_cases",
+) -> List[str]:
+    """Fetch newly released cases and convert the entire dataset."""
+
+    collect_new_cases(raw_dir)
     return convert_directory(raw_dir, output_dir, hidden_dir)
 
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -342,3 +342,12 @@ phases:
           - "Develop a precise prompt for the Judge LLM that instructs it to compare the candidate and ground-truth diagnoses based on clinical substance, not just lexical similarity, using the 5-point rubric."
           - "Add unit tests to `test_judge.py` to validate the new LLM-based evaluation logic with a variety of clinically similar but lexically different diagnostic pairs."
 
+      - id: "T31"
+        title: "Automate Case Updates"
+        description: >
+          Schedule a weekly workflow that fetches newly released NEJM CPC cases
+          and appends them to the dataset. The script skips already ingested
+          PMIDs to avoid duplicates.
+        labels: [automation, data]
+        done: true
+

--- a/tests/test_update_cases.py
+++ b/tests/test_update_cases.py
@@ -1,0 +1,18 @@
+import os
+from sdb.ingest import pipeline as pl
+
+
+def test_collect_new_cases(tmp_path, monkeypatch):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "case_001.txt").write_text("PMID: 111\n")
+
+    monkeypatch.setattr(
+        pl, "fetch_case_pmids", lambda count=304: ["111", "222"]
+    )
+    monkeypatch.setattr(pl, "fetch_case_text", lambda pmid: f"PMID: {pmid}")
+
+    paths = pl.collect_new_cases(str(raw_dir))
+    assert len(paths) == 1
+    assert os.path.basename(paths[0]) == "case_002.txt"
+    assert (raw_dir / "case_002.txt").read_text().strip() == "PMID: 222"


### PR DESCRIPTION
## Summary
- add `collect_new_cases` and `update_dataset` helpers to the ingestion pipeline
- provide `scripts/update_cases.py` as a CLI for appending new NEJM cases
- schedule weekly `update_cases` workflow to refresh the dataset
- document incremental updates in the README
- add task T31 to track the automation work
- cover new logic with tests

## Testing
- `pip install -r requirements-dev.txt`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a47ca7c58832a8c32af2b454a6398