### PR TITLE
Implement persona prompts for LLMEngine

### DIFF
--- a/prompts/challenger_system.txt
+++ b/prompts/challenger_system.txt
@@ -1,0 +1,1 @@
+You are Dr. Challenger. Critically review prior suggestions for bias or oversight. If you disagree, provide an alternative action. Otherwise, repeat the suggestion. Use the same XML format.

--- a/prompts/checklist_system.txt
+++ b/prompts/checklist_system.txt
@@ -1,0 +1,1 @@
+You are Dr. Checklist. Ensure the final action is safe, non-redundant, and uses the correct tag. Return exactly one <question>, <test>, or <diagnosis> element.

--- a/prompts/hypothesis_system.txt
+++ b/prompts/hypothesis_system.txt
@@ -1,0 +1,1 @@
+You are Dr. Hypothesis, an expert diagnostician. Review the case information and propose likely diagnoses or next steps. Respond with exactly one <question>, <test>, or <diagnosis> tag containing your recommendation.

--- a/prompts/stewardship_system.txt
+++ b/prompts/stewardship_system.txt
@@ -1,0 +1,1 @@
+You are Dr. Stewardship. Weigh the cost and patient impact of the proposed action. Modify it only if necessary to reduce harm or expense. Reply with one valid XML tag.

--- a/prompts/test_chooser_system.txt
+++ b/prompts/test_chooser_system.txt
@@ -1,0 +1,1 @@
+You are Dr. Test-Chooser. Consider the conversation so far and select the single most informative diagnostic test or question to clarify the differential. Reply using one <question> or <test> tag.

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -5,7 +5,7 @@ from .cost_estimator import CostEstimator, CptCost
 from .gatekeeper import Gatekeeper
 from .judge import Judge
 from .protocol import ActionType, build_action
-from .actions import PanelAction
+from .actions import PanelAction, parse_panel_action
 from .panel import VirtualPanel
 from .decision import DecisionEngine, RuleEngine, LLMEngine
 from .orchestrator import Orchestrator
@@ -27,6 +27,7 @@ __all__ = [
     "ActionType",
     "build_action",
     "PanelAction",
+    "parse_panel_action",
     "DecisionEngine",
     "RuleEngine",
     "LLMEngine",

--- a/sdb/actions.py
+++ b/sdb/actions.py
@@ -1,4 +1,8 @@
 from dataclasses import dataclass
+import json
+import re
+import xml.etree.ElementTree as ET
+
 from .protocol import ActionType
 
 
@@ -8,3 +12,52 @@ class PanelAction:
 
     action_type: ActionType
     content: str
+
+
+def parse_panel_action(text: str) -> PanelAction | None:
+    """Parse XML or JSON text into a :class:`PanelAction`.
+
+    Parameters
+    ----------
+    text:
+        Raw model output expected to contain a single action.
+
+    Returns
+    -------
+    PanelAction | None
+        Parsed action or ``None`` if parsing failed.
+    """
+
+    text = text.strip()
+    if not text:
+        return None
+
+    # Try XML-style parsing
+    try:
+        root = ET.fromstring(text)
+        tag = root.tag.lower()
+        if tag in {a.value for a in ActionType}:
+            content = (root.text or "").strip()
+            if content:
+                return PanelAction(ActionType(tag), content)
+    except ET.ParseError:
+        pass
+
+    m = re.search(r"<(question|test|diagnosis)>(.*?)</\\1>", text, re.I | re.S)
+    if m:
+        tag, content = m.group(1).lower(), m.group(2).strip()
+        if content:
+            return PanelAction(ActionType(tag), content)
+
+    try:
+        data = json.loads(text)
+        action = data.get("action") or data.get("type")
+        content = data.get("content")
+        if action and content:
+            action = str(action).lower()
+            if action in {a.value for a in ActionType}:
+                return PanelAction(ActionType(action), str(content).strip())
+    except Exception:
+        pass
+
+    return None

--- a/sdb/decision.py
+++ b/sdb/decision.py
@@ -4,8 +4,17 @@ from dataclasses import dataclass
 from typing import List, Set
 from abc import ABC, abstractmethod
 
-from .actions import PanelAction
+import os
+import time
+
+from .actions import PanelAction, parse_panel_action
 from .protocol import ActionType
+from .prompt_loader import load_prompt
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - openai optional
+    openai = None
 
 
 @dataclass
@@ -54,13 +63,55 @@ class RuleEngine(DecisionEngine):
 
 
 class LLMEngine(DecisionEngine):
-    """Placeholder LLM-based engine using the rule engine for now."""
+    """LLM-driven decision engine following the Chain of Debate."""
+
+    PERSONAS = [
+        "hypothesis_system",
+        "test_chooser_system",
+        "challenger_system",
+        "stewardship_system",
+        "checklist_system",
+    ]
 
     def __init__(self, model: str = "gpt-4"):
         self.model = model
         self.fallback = RuleEngine()
+        self.prompts = {name: load_prompt(name) for name in self.PERSONAS}
+        for name, text in self.prompts.items():
+            if not text.strip():
+                raise ValueError(f"Prompt {name} is empty")
+
+    def _chat(self, messages: list[dict]) -> str | None:
+        if openai is None:
+            return None
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            return None
+        openai.api_key = api_key
+        for _ in range(3):
+            try:
+                resp = openai.ChatCompletion.create(
+                    model=self.model,
+                    messages=messages,
+                    max_tokens=64,
+                )
+                return resp.choices[0].message["content"]
+            except Exception:  # pragma: no cover - network issues
+                time.sleep(1)
+        return None
 
     def decide(self, context: Context) -> PanelAction:
-        # In this demo we do not integrate an actual LLM API.
-        # The fallback rule engine is used instead.
-        return self.fallback.decide(context)
+        conversation = "\n".join(context.past_infos)
+        messages = []
+        for name in self.PERSONAS:
+            system = {"role": "system", "content": self.prompts[name]}
+            user = {"role": "user", "content": conversation}
+            messages.extend([system, user])
+            reply = self._chat(messages)
+            if reply is None:
+                return self.fallback.decide(context)
+            messages.append({"role": "assistant", "content": reply})
+        action = parse_panel_action(messages[-1]["content"])
+        if action is None:
+            return self.fallback.decide(context)
+        return action

--- a/tasks.yml
+++ b/tasks.yml
@@ -262,7 +262,7 @@ phases:
           - "Develop the cost-aware prompt for the **Dr. Stewardship** agent to analyze the cost-benefit of proposed tests."
           - "Implement a final prompt for the **Dr. Checklist** agent to ensure completeness and consistency before an action is taken."
           - "Create robust parsing logic to handle the LLM's output and convert it into a structured `PanelAction`."
-
+        done: true
       - id: "T24"
         title: "Integrate Semantic Search into Gatekeeper"
         description: >


### PR DESCRIPTION
## Summary
- add prompt templates for Hypothesis, Test-Chooser, Challenger, Stewardship and Checklist
- validate and use these prompts in a new LLMEngine implementation
- parse LLM output into PanelAction objects
- expose parse_panel_action in public API
- mark T23 complete in tasks.yml

## Testing
- `pip install -q numpy fastapi starlette uvicorn prometheus_client httpx flake8`
- `pytest -q`
- `flake8 .`

------
https://chatgpt.com/codex/tasks/task_e_686a49dd03d8832aa3569690e0541de7