### PR TITLE
Add sentence-transformer retrieval with RAG prompt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,5 @@ prometheus_client
 numpy>=1.26.4
 fastapi
 uvicorn
+sentence-transformers
 

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -14,7 +14,7 @@ from .ingest.convert import convert_directory
 from .ingest.pipeline import run_pipeline, update_dataset
 from .cpt_lookup import lookup_cpt
 from .metrics import start_metrics_server
-from .retrieval import SimpleEmbeddingIndex
+from .retrieval import SimpleEmbeddingIndex, SentenceTransformerIndex
 from .statistics import load_scores, permutation_test
 
 __all__ = [
@@ -40,6 +40,7 @@ __all__ = [
     "update_dataset",
     "start_metrics_server",
     "SimpleEmbeddingIndex",
+    "SentenceTransformerIndex",
     "load_scores",
     "permutation_test",
 ]

--- a/tasks.yml
+++ b/tasks.yml
@@ -274,6 +274,7 @@ phases:
           - "Modify the `Gatekeeper.answer_question` method to first query the vector index to retrieve relevant text chunks."
           - "Implement a RAG prompt that combines the user's question with the retrieved chunks to generate a precise answer using an LLM."
           - "Establish a fallback mechanism to use the old regex search if the semantic search fails to return relevant results."
+        done: true
 
       - id: "T25"
         title: "Build Interactive Physician UI for SDBench"

--- a/tests/test_gatekeeper.py
+++ b/tests/test_gatekeeper.py
@@ -78,6 +78,7 @@ def test_semantic_retrieval_enabled():
     q = build_action(ActionType.QUESTION, "cough")
     res = gk.answer_question(q)
     assert "cough" in res.content.lower()
+    assert "context:" in res.content.lower()
     assert res.synthetic is False
 
 

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,4 +1,4 @@
-from sdb.retrieval import SimpleEmbeddingIndex
+from sdb.retrieval import SimpleEmbeddingIndex, SentenceTransformerIndex
 
 
 def test_simple_embedding_index_returns_match():
@@ -7,3 +7,11 @@ def test_simple_embedding_index_returns_match():
     results = index.query("cough")
     assert results
     assert results[0][0] == "patient has a cough"
+
+
+def test_sentence_transformer_index_fallback():
+    """SentenceTransformerIndex should fall back when model is unavailable."""
+    docs = ["patient has a cough", "chest pain"]
+    index = SentenceTransformerIndex(docs, model_name="all-MiniLM-L6-v2")
+    results = index.query("cough")
+    assert results


### PR DESCRIPTION
## Summary
- implement `SentenceTransformerIndex` with automatic fallback
- index all case text in `Gatekeeper` using the new index
- build a RAG prompt with retrieved context in `Gatekeeper.answer_question`
- mark semantic search task as done in `tasks.yml`
- extend tests for the new index and update semantic retrieval test
- update development requirements

## Testing
- `pip install numpy`
- `pip install prometheus_client starlette`
- `pip install httpx`
- `pip install fastapi uvicorn`
- `pip install flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a4b9d8e38832a85682110b9b5fab0