### PR TITLE
Add multi-provider LLM client support

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12,6 +12,8 @@ from sdb import (
     VirtualPanel,
     RuleEngine,
     LLMEngine,
+    OpenAIClient,
+    OllamaClient,
     Orchestrator,
     Judge,
     Evaluator,
@@ -79,8 +81,13 @@ def main() -> None:
         help="Decision engine to use for the panel",
     )
     parser.add_argument(
+        "--llm-provider",
+        choices=["openai", "ollama"],
+        default="openai",
+        help="LLM provider for LLM engine",
+    )
+    parser.add_argument(
         "--llm-model",
-        choices=["gpt-4", "turbo"],
         default="gpt-4",
         help="Model name for LLM engine",
     )
@@ -200,7 +207,11 @@ def main() -> None:
     if args.panel_engine == "rule":
         engine = RuleEngine()
     else:
-        engine = LLMEngine(model=args.llm_model)
+        if args.llm_provider == "ollama":
+            client = OllamaClient()
+        else:
+            client = OpenAIClient()
+        engine = LLMEngine(model=args.llm_model, client=client)
 
     panel = VirtualPanel(decision_engine=engine)
 

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -8,6 +8,7 @@ from .protocol import ActionType, build_action
 from .actions import PanelAction, parse_panel_action
 from .panel import VirtualPanel
 from .decision import DecisionEngine, RuleEngine, LLMEngine
+from .llm_client import LLMClient, OpenAIClient, OllamaClient
 from .orchestrator import Orchestrator
 from .evaluation import Evaluator
 from .ingest.convert import convert_directory
@@ -37,6 +38,9 @@ __all__ = [
     "DecisionEngine",
     "RuleEngine",
     "LLMEngine",
+    "LLMClient",
+    "OpenAIClient",
+    "OllamaClient",
     "VirtualPanel",
     "Orchestrator",
     "Evaluator",

--- a/sdb/llm_client.py
+++ b/sdb/llm_client.py
@@ -1,0 +1,66 @@
+"""Abstractions for communicating with different LLM providers."""
+
+from __future__ import annotations
+
+import os
+import time
+from abc import ABC, abstractmethod
+from typing import List
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    openai = None
+
+import requests
+
+
+class LLMClient(ABC):
+    """Generic interface for chat-based language models."""
+
+    @abstractmethod
+    def chat(self, messages: List[dict], model: str) -> str | None:
+        """Return the assistant reply for the given messages."""
+        raise NotImplementedError
+
+
+class OpenAIClient(LLMClient):
+    """Client for the OpenAI chat completion API."""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+
+    def chat(self, messages: List[dict], model: str) -> str | None:
+        if openai is None or not self.api_key:
+            return None
+
+        openai.api_key = self.api_key
+        for _ in range(3):
+            try:
+                resp = openai.ChatCompletion.create(
+                    model=model,
+                    messages=messages,
+                    max_tokens=64,
+                )
+                return resp.choices[0].message["content"]
+            except Exception:  # pragma: no cover - network issues
+                time.sleep(1)
+        return None
+
+
+class OllamaClient(LLMClient):
+    """Client for a local Ollama server."""
+
+    def __init__(self, base_url: str = "http://localhost:11434") -> None:
+        self.base_url = base_url.rstrip("/")
+
+    def chat(self, messages: List[dict], model: str) -> str | None:
+        url = f"{self.base_url}/api/chat"
+        payload = {"model": model, "messages": messages}
+        try:
+            resp = requests.post(url, json=payload, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("message", {}).get("content")
+        except Exception:  # pragma: no cover - network or server issues
+            return None

--- a/tasks.yml
+++ b/tasks.yml
@@ -314,6 +314,7 @@ phases:
           - "Implement an `OllamaClient` that conforms to the interface and communicates with a local Ollama server endpoint."
           - "Update the `LLMEngine` to accept a configured client (OpenAI or Ollama) during initialization."
           - "Extend the main CLI with `--llm-provider` (choices: openai, ollama) and `--llm-model` flags to allow runtime selection of the desired model."
+        done: true
 
       - id: "T28"
         title: "Production-Grade Logging and Monitoring"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,6 +88,8 @@ def test_cli_flag_parsing(tmp_path):
         str(cost_file),
         "--panel-engine",
         "llm",
+        "--llm-provider",
+        "openai",
         "--llm-model",
         "turbo",
         "--quiet",

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,4 +1,9 @@
-from sdb.ensemble import DiagnosisResult, WeightedVoter, MetaPanel, cost_adjusted_selection
+from sdb.ensemble import (
+    DiagnosisResult,
+    WeightedVoter,
+    MetaPanel,
+    cost_adjusted_selection,
+)
 
 
 def test_weighted_voter_selects_highest_score():


### PR DESCRIPTION
## Summary
- add a provider-agnostic `LLMClient` interface
- implement `OpenAIClient` and `OllamaClient`
- update `LLMEngine` to use an injected client
- extend CLI with `--llm-provider` flag
- mark T27 complete in `tasks.yml`

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a530eb4c4832ab7b99eef8792213f