### PR TITLE
LLM-based judge scoring

### DIFF
--- a/prompts/judge_system.txt
+++ b/prompts/judge_system.txt
@@ -1,0 +1,7 @@
+You are Dr. Judge. Rate how clinically similar a candidate diagnosis is to the ground-truth diagnosis using this rubric:
+1 - completely incorrect or unrelated.
+2 - mostly incorrect with minor overlap.
+3 - partially correct but missing key aspects.
+4 - largely correct but not exact.
+5 - clinically equivalent or an obvious synonym.
+Return only the single digit 1-5.

--- a/sdb/judge.py
+++ b/sdb/judge.py
@@ -1,6 +1,10 @@
 import difflib
+import re
 from dataclasses import dataclass
 from typing import Dict, Any
+
+from .prompt_loader import load_prompt
+from .llm_client import LLMClient, OpenAIClient
 
 
 @dataclass
@@ -10,38 +14,68 @@ class Judgement:
 
 
 class Judge:
-    """Evaluate diagnosis with physician-authored rubric."""
+    """Evaluate diagnosis with physician-authored rubric via an LLM."""
 
-    def __init__(self, rubric: Dict[str, Any]):
-        """Create a judge with a scoring rubric.
+    def __init__(
+        self,
+        rubric: Dict[str, Any],
+        model: str = "gpt-4",
+        client: LLMClient | None = None,
+    ) -> None:
+        """Create a judge with a scoring rubric and LLM configuration."""
 
-        The rubric may define ``exact_threshold`` and ``partial_threshold``
-        similarity ratios. Defaults are 0.9 and 0.6.
-        """
         self.rubric = rubric
+        self.model = model
+        self.client = client or OpenAIClient()
+        self.prompt = load_prompt("judge_system")
         self.exact_threshold = float(rubric.get("exact_threshold", 0.9))
         self.partial_threshold = float(rubric.get("partial_threshold", 0.6))
 
+    def _llm_score(self, diagnosis: str, truth: str) -> int | None:
+        """Return a Likert score from the LLM or ``None`` on failure."""
+
+        messages = [
+            {"role": "system", "content": self.prompt},
+            {
+                "role": "user",
+                "content": f"Candidate: {diagnosis}\nTruth: {truth}",
+            },
+        ]
+        reply = self.client.chat(messages, self.model)
+        if reply is None:
+            return None
+        match = re.search(r"[1-5]", reply)
+        if match:
+            return int(match.group(0))
+        return None
+
     def evaluate(self, diagnosis: str, truth: str) -> Judgement:
         """Score the diagnosis against the truth and return judgement."""
-        d = diagnosis.strip().lower()
-        t = truth.strip().lower()
-        ratio = difflib.SequenceMatcher(None, d, t).ratio()
+        d = diagnosis.strip()
+        t = truth.strip()
+        score = self._llm_score(d, t)
 
-        if ratio >= self.exact_threshold:
-            score = 5
-            explanation = "Exact or near exact match"
-        elif ratio >= self.partial_threshold:
-            score = 4
-            explanation = "Reasonable partial match"
-        elif d and t and (d in t or t in d):
-            score = 3
-            explanation = "Minor overlap"
-        elif ratio > 0.3:
-            score = 2
-            explanation = "Poor match"
-        else:
-            score = 1
-            explanation = "Incorrect diagnosis"
+        if score is None:
+            ratio = difflib.SequenceMatcher(None, d.lower(), t.lower()).ratio()
+            if ratio >= self.exact_threshold:
+                score = 5
+            elif ratio >= self.partial_threshold:
+                score = 4
+            elif d and t and (
+                d.lower() in t.lower() or t.lower() in d.lower()
+            ):
+                score = 3
+            elif ratio > 0.3:
+                score = 2
+            else:
+                score = 1
 
-        return Judgement(score=score, explanation=explanation)
+        explanations = {
+            5: "Exact or near exact match",
+            4: "Reasonable partial match",
+            3: "Minor overlap",
+            2: "Poor match",
+            1: "Incorrect diagnosis",
+        }
+
+        return Judgement(score=score, explanation=explanations.get(score, ""))

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1,12 +1,23 @@
 from sdb.judge import Judge
 
 
-def test_judge_scoring():
-    rubric = {"exact_threshold": 0.9, "partial_threshold": 0.6}
-    j = Judge(rubric)
-    res = j.evaluate("Influenza", "Influenza")
+class DummyClient:
+    def chat(self, messages, model):
+        text = messages[-1]["content"].lower()
+        if "heart attack" in text and "myocardial infarction" in text:
+            return "5"
+        if "influenza virus" in text and "influenza" in text:
+            return "4"
+        if "common cold" in text and "influenza" in text:
+            return "2"
+        return "1"
+
+
+def test_judge_llm_synonyms():
+    j = Judge({}, client=DummyClient())
+    res = j.evaluate("heart attack", "myocardial infarction")
     assert res.score == 5
-    res = j.evaluate("Influenza A", "Influenza")
-    assert res.score >= 4
-    res = j.evaluate("Cold", "Influenza")
-    assert res.score <= 2
+    res = j.evaluate("Influenza virus", "Influenza")
+    assert res.score == 4
+    res = j.evaluate("Common cold", "Influenza")
+    assert res.score == 2


### PR DESCRIPTION
## Summary
- implement an LLM-driven judge with fallback to `SequenceMatcher`
- add a clinical similarity prompt for the judge
- update tests for new judge logic using varied phrasing and synonyms

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a5b95290c832a9e3275e4e795d0cf