### PR TITLE
Enable websocket reply streaming

### DIFF
--- a/sdb/ui/templates/index.html
+++ b/sdb/ui/templates/index.html
@@ -32,8 +32,24 @@ function App() {
       const socket = new WebSocket(`ws://${location.host}/ws?token=${data.token}`);
       socket.onmessage = (ev) => {
         const d = JSON.parse(ev.data);
-        setLog(l => [...l, {sender: 'Gatekeeper', text: d.reply}]);
-        setCost(d.total_spent);
+        setLog(l => {
+          const log = [...l];
+          if (
+            log.length === 0 ||
+            log[log.length - 1].sender !== 'Gatekeeper' ||
+            log[log.length - 1].done
+          ) {
+            log.push({sender: 'Gatekeeper', text: d.reply, done: d.done});
+          } else {
+            log[log.length - 1] = {
+              ...log[log.length - 1],
+              text: log[log.length - 1].text + d.reply,
+              done: d.done
+            };
+          }
+          return log;
+        });
+        if (d.done) setCost(d.total_spent);
       };
       setWs(socket);
     } else {

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -12,10 +12,22 @@ def test_websocket_chat():
     token = res.json()["token"]
     with client.websocket_connect(f"/ws?token={token}") as ws:
         ws.send_json({"action": "question", "content": "cough"})
-        data = ws.receive_json()
-        assert "reply" in data
-        assert data["total_spent"] == 0.0
+        parts = []
+        while True:
+            data = ws.receive_json()
+            parts.append(data["reply"])
+            if data["done"]:
+                assert data["total_spent"] == 0.0
+                break
+        assert len(parts) > 1
+
         ws.send_json({"action": "test", "content": "complete blood count"})
-        data = ws.receive_json()
-        assert data["cost"] == 10.0
-        assert data["total_spent"] == 10.0
+        parts = []
+        while True:
+            data = ws.receive_json()
+            parts.append(data["reply"])
+            if data["done"]:
+                assert data["cost"] == 10.0
+                assert data["total_spent"] == 10.0
+                break
+        assert len(parts) > 1


### PR DESCRIPTION
## Summary
- stream chatbot replies in small fragments from FastAPI
- update the browser client to append text as fragments arrive
- test that websocket responses are streamed

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b2e96e66c832aa30bdc96972a0e3a