### PR TITLE
Use tiktoken for token counting

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,4 +11,5 @@ numpy>=1.26.4
 fastapi
 uvicorn
 sentence-transformers
+tiktoken
 

--- a/sdb/llm_client.py
+++ b/sdb/llm_client.py
@@ -10,6 +10,11 @@ from abc import ABC, abstractmethod
 from typing import List
 
 try:
+    import tiktoken  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    tiktoken = None
+
+try:
     import openai  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     openai = None
@@ -57,6 +62,9 @@ class LLMClient(ABC):
     def _count_tokens(messages: List[dict]) -> int:
         """Approximate the number of tokens in a list of messages."""
 
+        if tiktoken is not None:
+            enc = tiktoken.get_encoding("cl100k_base")
+            return sum(len(enc.encode(m.get("content", ""))) for m in messages)
         return sum(len(m.get("content", "").split()) for m in messages)
 
 

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,4 +1,10 @@
 from sdb.retrieval import SimpleEmbeddingIndex, SentenceTransformerIndex
+from sdb.llm_client import LLMClient
+
+
+class DummyClient(LLMClient):
+    def _chat(self, messages, model):
+        return None
 
 
 def test_simple_embedding_index_returns_match():
@@ -15,3 +21,10 @@ def test_sentence_transformer_index_fallback():
     index = SentenceTransformerIndex(docs, model_name="all-MiniLM-L6-v2")
     results = index.query("cough")
     assert results
+
+
+def test_count_tokens_bpe():
+    """LLMClient should tokenize using BPE when available."""
+
+    msgs = [{"role": "user", "content": "erythema"}]
+    assert DummyClient._count_tokens(msgs) == 3


### PR DESCRIPTION
## Summary
- add `tiktoken` to development requirements
- switch `LLMClient._count_tokens` to BPE token counting
- test new token counting behaviour

## Testing
- `python -m flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4f37068c832abb717e65cbbf63ad