### PR TITLE
Add metrics port option and tests

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -309,9 +309,15 @@ def main() -> None:
         default="unconstrained",
         help="Run mode",
     )
+    parser.add_argument(
+        "--metrics-port",
+        type=int,
+        default=None,
+        help="Port for Prometheus metrics server (default 8000)",
+    )
     args = parser.parse_args()
 
-    start_metrics_server()
+    start_metrics_server(args.metrics_port)
 
     if args.convert:
         run_pipeline(

--- a/sdb/metrics.py
+++ b/sdb/metrics.py
@@ -1,5 +1,6 @@
 """Prometheus metrics helpers for MAI-DxO."""
 
+import os
 from prometheus_client import Counter, Histogram, start_http_server
 
 ORCHESTRATOR_TURNS = Counter(
@@ -27,6 +28,18 @@ LLM_TOKENS = Counter(
 )
 
 
-def start_metrics_server(port: int = 8000) -> None:
-    """Start a Prometheus metrics HTTP server."""
+def start_metrics_server(port: int | None = None) -> None:
+    """Start a Prometheus metrics HTTP server.
+
+    Parameters
+    ----------
+    port:
+        Port for the HTTP server. If ``None`` the value from the
+        ``SDB_METRICS_PORT`` environment variable is used when set,
+        otherwise ``8000``.
+    """
+
+    if port is None:
+        env = os.getenv("SDB_METRICS_PORT")
+        port = int(env) if env else 8000
     start_http_server(port)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,106 @@
+import json
+import csv
+import sys
+
+import cli
+from sdb.metrics import start_metrics_server
+
+
+def _prepare_args(tmp_path):
+    cases = [{"id": "1", "summary": "x", "full_text": "y"}]
+    case_file = tmp_path / "cases.json"
+    with open(case_file, "w", encoding="utf-8") as f:
+        json.dump(cases, f)
+
+    rubric_file = tmp_path / "rubric.json"
+    with open(rubric_file, "w", encoding="utf-8") as f:
+        json.dump({}, f)
+
+    cost_file = tmp_path / "costs.csv"
+    with open(cost_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["test_name", "cpt_code", "price"]
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "test_name": "complete blood count",
+                "cpt_code": "1",
+                "price": "1",
+            }
+        )
+
+    return case_file, rubric_file, cost_file
+
+
+def test_start_metrics_server_env(monkeypatch):
+    port = {}
+
+    def fake_start(port_arg):
+        port["value"] = port_arg
+
+    monkeypatch.setattr("sdb.metrics.start_http_server", fake_start)
+    monkeypatch.setenv("SDB_METRICS_PORT", "9100")
+    start_metrics_server(None)
+    assert port["value"] == 9100
+
+
+def test_cli_metrics_port_flag(tmp_path, monkeypatch):
+    case_file, rubric_file, cost_file = _prepare_args(tmp_path)
+
+    called = {}
+
+    def fake_start(port):
+        called["port"] = port
+
+    monkeypatch.setattr("sdb.metrics.start_http_server", fake_start)
+    argv = [
+        "cli.py",
+        "--db",
+        str(case_file),
+        "--case",
+        "1",
+        "--rubric",
+        str(rubric_file),
+        "--costs",
+        str(cost_file),
+        "--panel-engine",
+        "rule",
+        "--llm-model",
+        "gpt-4",
+        "--metrics-port",
+        "9200",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    cli.main()
+    assert called["port"] == 9200
+
+
+def test_cli_metrics_port_env(tmp_path, monkeypatch):
+    case_file, rubric_file, cost_file = _prepare_args(tmp_path)
+
+    called = {}
+
+    def fake_start(port):
+        called["port"] = port
+
+    monkeypatch.setattr("sdb.metrics.start_http_server", fake_start)
+    monkeypatch.setenv("SDB_METRICS_PORT", "9300")
+    argv = [
+        "cli.py",
+        "--db",
+        str(case_file),
+        "--case",
+        "1",
+        "--rubric",
+        str(rubric_file),
+        "--costs",
+        str(cost_file),
+        "--panel-engine",
+        "rule",
+        "--llm-model",
+        "gpt-4",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    cli.main()
+    assert called["port"] == 9300


### PR DESCRIPTION
## Summary
- configure metrics port via `--metrics-port` CLI option or env var
- document metrics configuration in `sdb.metrics.start_metrics_server`
- add tests for custom metrics port handling

## Testing
- `pip install -q pydantic fastapi uvicorn starlette requests beautifulsoup4 numpy prometheus_client httpx`
- `pip install -q flake8 tiktoken`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b5aeee540832a89178eb026836d99