### PR TITLE
Add helper for installing dev dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,10 @@ Thank you for wanting to contribute! This project uses several development tools
 ## Setup
 
 1. Create a Python virtual environment and activate it.
-2. Install development dependencies:
+2. Install development dependencies (requires Make):
 
    ```bash
-   pip install -r requirements-dev.txt
+   make install-dev
    ```
 
 3. Install the pre-commit hooks so they run automatically on each commit:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: install-dev
+install-dev:
+	python -m pip install -r requirements-dev.txt


### PR DESCRIPTION
## Summary
- add a simple Makefile with `install-dev` target
- document `make install-dev` usage in `CONTRIBUTING.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_686b61edfae0832aa300803fc0058b81