### PR TITLE
Fix duplicate task ID in backlog

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -414,7 +414,7 @@ phases:
           observations into the internal SDBench case format.
         labels: [feature, interoperability]
 
-      - id: "T39"
+      - id: "T39a"
         title: "Asynchronous Batch Evaluation"
         description: >
           Run large-scale case evaluations concurrently to reduce


### PR DESCRIPTION
## Summary
- resolve duplicate task id by renaming one entry to `T39a`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_686b691b6e5c832aa05e3de8f868fac4