### PR TITLE
Add instructions for installing dev dependencies

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,3 +49,15 @@ python -m build
 
 The archives will be written to the `dist/` directory as
 `sdb-<version>.tar.gz` and `sdb-<version>-py3-none-any.whl`.
+
+## Development Dependencies
+
+To run the unit tests and other developer tools, install the additional
+requirements listed in `requirements-dev.txt`:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+The `pytest` suite relies on packages such as `numpy`, `httpx`, and
+`starlette`.


### PR DESCRIPTION
## Summary
- document how to install the development requirements
- explain that pytest needs packages like numpy, httpx and starlette

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_686b6aba9674832a8e5e5ee6dab70dac