### PR TITLE
Add missing dev deps and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ metrics = bench.run()
 print(metrics)
 ```
 
+### Running Tests
+
+The test suite depends on additional packages such as `httpx` and
+`starlette`. Install the development requirements first:
+
+```bash
+pip install -r requirements-dev.txt
+pytest -q
+```
+
 ### Statistical Significance Testing
 
 After running evaluations you can test whether a variant's scores differ

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,6 @@ fastapi
 uvicorn
 sentence-transformers
 tiktoken
+httpx
+starlette
 


### PR DESCRIPTION
## Summary
- add `httpx` and `starlette` to `requirements-dev.txt`
- document installing dev requirements for running the tests

## Testing
- `pre-commit run --files requirements-dev.txt README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b9e155680832a875379162fbd7e50