### PR TITLE
Fix numbering for async batch tasks

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -415,7 +415,7 @@ phases:
           observations into the internal SDBench case format.
         labels: [feature, interoperability]
 
-      - id: "T39a"
+      - id: "T39"
         title: "Asynchronous Batch Evaluation"
         description: >
           Run large-scale case evaluations concurrently to reduce


### PR DESCRIPTION
## Summary
- fix the numbering for the async batch evaluation task

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_686ba00e6a44832a9502f86150ab1815