### PR TITLE
Ensure tests install optional packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ print(metrics)
 
 ### Running Tests
 
-The test suite depends on additional packages such as `httpx` and
-`starlette`. Install the development requirements first:
+The test suite depends on additional packages such as `httpx`,
+`starlette`, and `pydantic`. Install the development requirements first:
 
 ```bash
 pip install -r requirements-dev.txt

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,5 +59,5 @@ requirements listed in `requirements-dev.txt`:
 pip install -r requirements-dev.txt
 ```
 
-The `pytest` suite relies on packages such as `numpy`, `httpx`, and
-`starlette`.
+The `pytest` suite relies on packages such as `numpy`, `httpx`,
+`starlette`, and `pydantic`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,4 +14,5 @@ sentence-transformers
 tiktoken
 httpx
 starlette
+pydantic
 


### PR DESCRIPTION
## Summary
- document that pydantic is needed for the test suite
- add pydantic to development requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ba76ced50832ab4bb16457f6e3d1a