### PR TITLE
Fix duplicate task id

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -415,7 +415,7 @@ phases:
           observations into the internal SDBench case format.
         labels: [feature, interoperability]
 
-      - id: "T39"
+      - id: "T39a"
         title: "Asynchronous Batch Evaluation"
         description: >
           Run large-scale case evaluations concurrently to reduce


### PR DESCRIPTION
## Summary
- update tasks.yml so "Asynchronous Batch Evaluation" has unique id `T39a`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_686badd846c4832a85e1e7ef6bb1f779