### PR TITLE
Implement FHIR export utilities

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -18,6 +18,7 @@ from .metrics import start_metrics_server
 from .retrieval import SimpleEmbeddingIndex, SentenceTransformerIndex
 from .statistics import load_scores, permutation_test
 from .sqlite_db import load_from_sqlite, save_to_sqlite
+from .fhir_export import transcript_to_fhir, ordered_tests_to_fhir
 from .ensemble import (
     DiagnosisResult,
     WeightedVoter,
@@ -60,4 +61,6 @@ __all__ = [
     "WeightedVoter",
     "MetaPanel",
     "cost_adjusted_selection",
+    "transcript_to_fhir",
+    "ordered_tests_to_fhir",
 ]

--- a/sdb/fhir_export.py
+++ b/sdb/fhir_export.py
@@ -1,0 +1,69 @@
+"""FHIR conversion utilities for orchestrator outputs."""
+
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+
+def transcript_to_fhir(
+    transcript: Iterable[Tuple[str, str]], patient_id: str = "example"
+) -> dict:
+    """Convert a session transcript to a FHIR Bundle.
+
+    Parameters
+    ----------
+    transcript:
+        Iterable of ``(speaker, text)`` pairs.
+    patient_id:
+        Identifier for the patient used in ``Patient`` references.
+
+    Returns
+    -------
+    dict
+        Dictionary representing a FHIR ``Bundle`` resource containing
+        ``Communication`` entries for each transcript message.
+    """
+    entries = []
+    for idx, (speaker, text) in enumerate(transcript, start=1):
+        comm = {
+            "resourceType": "Communication",
+            "id": f"comm-{idx}",
+            "status": "completed",
+            "subject": {"reference": f"Patient/{patient_id}"},
+            "sender": {"display": speaker},
+            "payload": [{"contentString": text}],
+        }
+        entries.append({"resource": comm})
+    return {"resourceType": "Bundle", "type": "collection", "entry": entries}
+
+
+def ordered_tests_to_fhir(
+    tests: Iterable[str], patient_id: str = "example"
+) -> dict:
+    """Convert ordered tests to a FHIR Bundle of ServiceRequests.
+
+    Parameters
+    ----------
+    tests:
+        Iterable of test names ordered during a session.
+    patient_id:
+        Identifier for the patient used in ``Patient`` references.
+
+    Returns
+    -------
+    dict
+        Dictionary representing a FHIR ``Bundle`` with ``ServiceRequest``
+        entries for each test.
+    """
+    entries = []
+    for idx, name in enumerate(tests, start=1):
+        req = {
+            "resourceType": "ServiceRequest",
+            "id": f"req-{idx}",
+            "status": "completed",
+            "intent": "order",
+            "subject": {"reference": f"Patient/{patient_id}"},
+            "code": {"text": name},
+        }
+        entries.append({"resource": req})
+    return {"resourceType": "Bundle", "type": "collection", "entry": entries}

--- a/tests/test_fhir_export.py
+++ b/tests/test_fhir_export.py
@@ -1,0 +1,16 @@
+from sdb.fhir_export import transcript_to_fhir, ordered_tests_to_fhir
+
+
+def test_transcript_to_fhir():
+    transcript = [("panel", "hello"), ("gatekeeper", "hi")]
+    bundle = transcript_to_fhir(transcript, patient_id="1")
+    assert bundle["resourceType"] == "Bundle"
+    assert bundle["entry"][0]["resource"]["resourceType"] == "Communication"
+    assert bundle["entry"][0]["resource"]["sender"]["display"] == "panel"
+
+
+def test_ordered_tests_to_fhir():
+    tests = ["cbc", "bmp"]
+    bundle = ordered_tests_to_fhir(tests, patient_id="1")
+    assert bundle["entry"][0]["resource"]["code"]["text"] == "cbc"
+    assert bundle["entry"][1]["resource"]["resourceType"] == "ServiceRequest"


### PR DESCRIPTION
## Summary
- add utility functions for converting transcripts and ordered tests to FHIR Bundles
- expose new helpers in `sdb.__init__`
- test FHIR export behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb4b48844832ab1b4316ec159c619