### PR TITLE
Implement cross-encoder reranking

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -15,7 +15,11 @@ from .ingest.convert import convert_directory
 from .ingest.pipeline import run_pipeline, update_dataset
 from .cpt_lookup import lookup_cpt
 from .metrics import start_metrics_server
-from .retrieval import SimpleEmbeddingIndex, SentenceTransformerIndex
+from .retrieval import (
+    SimpleEmbeddingIndex,
+    SentenceTransformerIndex,
+    CrossEncoderReranker,
+)
 from .statistics import load_scores, permutation_test
 from .sqlite_db import load_from_sqlite, save_to_sqlite
 from .fhir_export import transcript_to_fhir, ordered_tests_to_fhir
@@ -55,6 +59,7 @@ __all__ = [
     "start_metrics_server",
     "SimpleEmbeddingIndex",
     "SentenceTransformerIndex",
+    "CrossEncoderReranker",
     "load_scores",
     "permutation_test",
     "DiagnosisResult",

--- a/tasks.yml
+++ b/tasks.yml
@@ -402,6 +402,7 @@ phases:
           Improve semantic retrieval by re-ranking top passages
           with a cross-encoder model for higher precision.
         labels: [enhancement, ml]
+        done: true
 
       - id: "T37"
         title: "Automatic CMS Pricing Updates"


### PR DESCRIPTION
## Summary
- integrate a `CrossEncoderReranker` helper into retrieval
- allow `SentenceTransformerIndex` to rerank with a cross encoder
- export reranker from `sdb.__init__`
- mark T36 complete in `tasks.yml`
- test cross-encoder reranking logic

## Testing
- `pytest tests/test_retrieval.py -q`
- `pytest tests/test_retrieval.py::test_cross_encoder_reranking -q`


------
https://chatgpt.com/codex/tasks/task_e_686bbb9a3100832abd4810ffbc97a047