### PR TITLE
Implement CMS pricing updater

### DIFF
--- a/.github/workflows/update_pricing.yml
+++ b/.github/workflows/update_pricing.yml
@@ -1,0 +1,33 @@
+name: Update CMS Pricing
+
+on:
+  schedule:
+    - cron: '0 6 1 * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Update pricing
+        run: python scripts/update_cms_pricing.py
+      - name: Commit changes
+        run: |
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@github.com'
+          git add data/cpt_lookup.csv
+          if git diff --cached --quiet; then
+            echo "No pricing updates" && exit 0
+          fi
+          git commit -m 'chore: update CMS pricing'
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/update_cms_pricing.py
+++ b/scripts/update_cms_pricing.py
@@ -1,0 +1,106 @@
+"""Update local CPT pricing using data from CMS."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import os
+import zipfile
+from typing import Dict
+
+import requests
+
+DEFAULT_URL = os.getenv(
+    "CMS_PRICING_URL",
+    "https://download.cms.gov/MedicareClinicalLabFeeSched/20CLAB.zip",
+)
+DEFAULT_PATH = os.path.join("data", "cpt_lookup.csv")
+
+
+def _fetch_cms_prices(url: str = DEFAULT_URL) -> Dict[str, float]:
+    """Return mapping of CPT/HCPCS codes to prices from ``url``."""
+
+    resp = requests.get(url, timeout=60)
+    resp.raise_for_status()
+    content = resp.content
+    if url.lower().endswith(".zip"):
+        with zipfile.ZipFile(io.BytesIO(content)) as zf:
+            name = next(
+                (n for n in zf.namelist() if n.lower().endswith(".csv")),
+                None,
+            )
+            if name is None:
+                raise ValueError("ZIP archive contains no CSV file")
+            data = io.TextIOWrapper(zf.open(name), encoding="utf-8")
+            reader = csv.DictReader(data)
+            rows = list(reader)
+    else:
+        text = content.decode("utf-8")
+        rows = list(csv.DictReader(io.StringIO(text)))
+
+    mapping: Dict[str, float] = {}
+    for row in rows:
+        lower = {k.lower(): v for k, v in row.items()}
+        code = (
+            lower.get("cpt_code")
+            or lower.get("hcpcs")
+            or lower.get("code")
+            or lower.get("hcpcs code")
+        )
+        price = (
+            lower.get("price")
+            or lower.get("rate")
+            or lower.get("payment_rate")
+            or lower.get("payment rate")
+            or lower.get("2024 payment rate")
+        )
+        if not code or not price:
+            continue
+        try:
+            mapping[code.strip()] = float(str(price).strip().lstrip("$"))
+        except ValueError:
+            continue
+    return mapping
+
+
+def refresh_pricing(path: str = DEFAULT_PATH, url: str = DEFAULT_URL) -> None:
+    """Update ``path`` with prices fetched from ``url``."""
+
+    prices = _fetch_cms_prices(url)
+    rows = []
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            code = row.get("cpt_code", "").strip()
+            if code in prices:
+                row["price"] = str(prices[code])
+            rows.append(row)
+
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=["test_name", "cpt_code", "price"],
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Update CPT pricing from CMS")
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_URL,
+        help="CMS CSV or ZIP URL",
+    )
+    parser.add_argument(
+        "--path",
+        default=DEFAULT_PATH,
+        help="Path to cpt_lookup.csv",
+    )
+    parsed = parser.parse_args(args)
+    refresh_pricing(parsed.path, parsed.url)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/sdb/retrieval.py
+++ b/sdb/retrieval.py
@@ -102,7 +102,10 @@ class SimpleEmbeddingIndex:
 class CrossEncoderReranker:
     """Optional cross-encoder for re-ranking retrieved passages."""
 
-    def __init__(self, model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"):
+    def __init__(
+        self,
+        model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2",
+    ):
         self.model_name = model_name
         if TRANSFORMERS_AVAILABLE:
             try:

--- a/tasks.yml
+++ b/tasks.yml
@@ -410,6 +410,7 @@ phases:
           Provide a script that fetches the latest CMS pricing table
           and refreshes the local cost database.
         labels: [automation, data]
+        done: true
 
       - id: "T38"
         title: "FHIR Case Import"

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -82,8 +82,16 @@ def test_cross_encoder_reranking(monkeypatch):
         def rerank(self, query, passages):
             return [(passages[1], 1.0), (passages[0], 0.5)]
 
-    monkeypatch.setattr(retrieval, "SentenceTransformer", lambda name: DummyModel())
-    monkeypatch.setattr(retrieval, "CrossEncoderReranker", lambda name=None: DummyReranker())
+    monkeypatch.setattr(
+        retrieval,
+        "SentenceTransformer",
+        lambda name: DummyModel(),
+    )
+    monkeypatch.setattr(
+        retrieval,
+        "CrossEncoderReranker",
+        lambda name=None: DummyReranker(),
+    )
 
     index = retrieval.SentenceTransformerIndex(
         docs, model_name="dummy", cross_encoder_name="dummy"

--- a/tests/test_update_cms_pricing.py
+++ b/tests/test_update_cms_pricing.py
@@ -1,0 +1,36 @@
+import csv
+from types import SimpleNamespace
+
+import scripts.update_cms_pricing as ucp
+
+
+def test_refresh_pricing(tmp_path, monkeypatch):
+    cms_csv = "code,rate\n85027,11.0\n"
+
+    def fake_get(url, timeout=60):
+        return SimpleNamespace(
+            content=cms_csv.encode(),
+            text=cms_csv,
+            status_code=200,
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr(ucp, "requests", SimpleNamespace(get=fake_get))
+
+    path = tmp_path / "cpt.csv"
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["test_name", "cpt_code", "price"],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {"test_name": "cbc", "cpt_code": "85027", "price": "9"}
+        )
+
+    ucp.refresh_pricing(str(path), "https://example.com/data.csv")
+
+    with open(path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert rows[0]["price"] == "11.0"


### PR DESCRIPTION
## Summary
- implement script to refresh CPT pricing from CMS data
- add CI workflow to run pricing updates monthly
- mark task T37 complete
- fix flake8 issues
- test CMS pricing updater

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bbe6595b4832a86ad27a07036bd2c