### PR TITLE
Add FHIR case import utilities

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -23,6 +23,7 @@ from .retrieval import (
 from .statistics import load_scores, permutation_test
 from .sqlite_db import load_from_sqlite, save_to_sqlite
 from .fhir_export import transcript_to_fhir, ordered_tests_to_fhir
+from .fhir_import import diagnostic_report_to_case, bundle_to_case
 from .ensemble import (
     DiagnosisResult,
     WeightedVoter,
@@ -68,4 +69,6 @@ __all__ = [
     "cost_adjusted_selection",
     "transcript_to_fhir",
     "ordered_tests_to_fhir",
+    "diagnostic_report_to_case",
+    "bundle_to_case",
 ]

--- a/sdb/fhir_import.py
+++ b/sdb/fhir_import.py
@@ -1,0 +1,105 @@
+"""FHIR import utilities to generate SDBench cases from DiagnosticReports."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Optional
+
+
+def _strip_html(text: str) -> str:
+    """Return ``text`` with HTML tags removed."""
+    return re.sub(r"<[^>]+>", "", text).strip()
+
+
+def observation_text(obs: Dict[str, object]) -> str:
+    """Return a plain text representation of a FHIR ``Observation``."""
+
+    if "valueString" in obs:
+        return str(obs["valueString"])
+    if "valueCodeableConcept" in obs:
+        v = obs["valueCodeableConcept"]
+        if isinstance(v, dict):
+            return str(v.get("text", ""))
+    if "valueQuantity" in obs:
+        q = obs["valueQuantity"]
+        if isinstance(q, dict):
+            value = q.get("value")
+            unit = q.get("unit") or q.get("code", "")
+            prefix = obs.get("code", {}).get("text", "")
+            parts = []
+            if prefix:
+                parts.append(f"{prefix}:")
+            if value is not None:
+                parts.append(str(value))
+            if unit:
+                parts.append(str(unit))
+            return " ".join(parts).strip()
+    if "text" in obs and isinstance(obs["text"], dict):
+        div = obs["text"].get("div")
+        if div:
+            return _strip_html(str(div))
+    return str(obs.get("code", {}).get("text", ""))
+
+
+def diagnostic_report_to_case(
+    report: Dict[str, object],
+    case_id: str = "case_001",
+    bundle: Optional[Dict[str, object]] = None,
+) -> Dict[str, object]:
+    """Convert a FHIR ``DiagnosticReport`` into SDBench case format."""
+
+    summary = str(report.get("conclusion", ""))
+    if not summary and isinstance(report.get("text"), dict):
+        div = report["text"].get("div")
+        if div:
+            summary = _strip_html(str(div))
+
+    observations: List[Dict[str, object]] = []
+    for contained in report.get("contained", []):
+        if (
+            isinstance(contained, dict)
+            and contained.get("resourceType") == "Observation"
+        ):
+            observations.append(contained)
+
+    if bundle:
+        for entry in bundle.get("entry", []):
+            res = entry.get("resource") if isinstance(entry, dict) else None
+            if (
+                isinstance(res, dict)
+                and res.get("resourceType") == "Observation"
+            ):
+                observations.append(res)
+
+    obs_by_id = {obs.get("id"): obs for obs in observations if obs.get("id")}
+
+    steps: List[Dict[str, object]] = []
+    for idx, ref in enumerate(report.get("result", []), start=1):
+        ref_str = ""
+        if isinstance(ref, str):
+            ref_str = ref
+        elif isinstance(ref, dict):
+            ref_str = str(ref.get("reference", ""))
+        target = ref_str.lstrip("#").split("/")[-1]
+        obs = obs_by_id.get(target)
+        if obs:
+            text = observation_text(obs)
+            if text:
+                steps.append({"id": idx, "text": text})
+
+    return {"id": case_id, "summary": summary, "steps": steps}
+
+
+def bundle_to_case(
+    bundle: Dict[str, object], case_id: str = "case_001"
+) -> Dict[str, object]:
+    """Return the first ``DiagnosticReport`` in ``bundle`` as a case."""
+
+    for entry in bundle.get("entry", []):
+        res = entry.get("resource") if isinstance(entry, dict) else None
+        if (
+            isinstance(res, dict)
+            and res.get("resourceType") == "DiagnosticReport"
+        ):
+            return diagnostic_report_to_case(res, case_id, bundle)
+    raise ValueError("No DiagnosticReport found in bundle")

--- a/tasks.yml
+++ b/tasks.yml
@@ -418,6 +418,7 @@ phases:
           Add utilities to convert FHIR diagnostic reports and
           observations into the internal SDBench case format.
         labels: [feature, interoperability]
+        done: true
 
       - id: "T39a"
         title: "Asynchronous Batch Evaluation"

--- a/tests/test_fhir_import.py
+++ b/tests/test_fhir_import.py
@@ -1,0 +1,64 @@
+from sdb.fhir_import import diagnostic_report_to_case, bundle_to_case
+
+
+def test_diagnostic_report_to_case():
+    report = {
+        "resourceType": "DiagnosticReport",
+        "id": "dr1",
+        "conclusion": "Patient summary",
+        "result": [
+            {"reference": "#o1"},
+            {"reference": "#o2"},
+        ],
+        "contained": [
+            {
+                "resourceType": "Observation",
+                "id": "o1",
+                "valueString": "Step 1",
+            },
+            {
+                "resourceType": "Observation",
+                "id": "o2",
+                "valueString": "Step 2",
+            },
+        ],
+    }
+    case = diagnostic_report_to_case(report, case_id="c1")
+    assert case["id"] == "c1"
+    assert case["summary"] == "Patient summary"
+    assert [s["text"] for s in case["steps"]] == ["Step 1", "Step 2"]
+
+
+def test_bundle_to_case():
+    report = {
+        "resourceType": "DiagnosticReport",
+        "id": "dr1",
+        "conclusion": "summary",
+        "result": [
+            {"reference": "Observation/o1"},
+            {"reference": "Observation/o2"},
+        ],
+    }
+    bundle = {
+        "resourceType": "Bundle",
+        "entry": [
+            {"resource": report},
+            {
+                "resource": {
+                    "resourceType": "Observation",
+                    "id": "o1",
+                    "valueString": "foo",
+                }
+            },
+            {
+                "resource": {
+                    "resourceType": "Observation",
+                    "id": "o2",
+                    "valueString": "bar",
+                }
+            },
+        ],
+    }
+    case = bundle_to_case(bundle, case_id="case")
+    assert len(case["steps"]) == 2
+    assert case["steps"][0]["text"] == "foo"


### PR DESCRIPTION
## Summary
- implement `diagnostic_report_to_case` and `bundle_to_case` to convert FHIR
  diagnostic reports and observations into SDBench cases
- export new helpers from the package
- mark task T38 complete
- test FHIR import functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc4d2228c832a878334e5e9c141a7