### PR TITLE
Add async batch evaluation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,27 @@ The command prints a p-value. Values below 0.05 indicate the observed
 difference in the selected column is unlikely under the null hypothesis of no
 effect.
 
+### Asynchronous Batch Evaluation
+
+Use the :func:`batch_evaluate` helper to run case evaluations concurrently:
+
+```python
+from sdb.evaluation import batch_evaluate
+
+def run_case(cid: str) -> dict[str, str]:
+    ...
+
+case_ids = ["1", "2"]
+results = batch_evaluate(case_ids, run_case, concurrency=4)
+```
+
+Equivalent functionality is available via the CLI subcommand:
+
+```bash
+python cli.py batch-eval --db cases.json --rubric rubric.json \
+    --costs costs.csv --output results.csv --concurrency 4
+```
+
 ---
 
 ## Repository Structure

--- a/docs/batch_eval.md
+++ b/docs/batch_eval.md
@@ -1,0 +1,26 @@
+# Asynchronous Batch Evaluation
+
+Large scale experiments can be run concurrently to shorten evaluation time. The
+`batch_evaluate` helper executes a user provided case function across multiple
+IDs using `asyncio`.
+
+```python
+from sdb.evaluation import batch_evaluate
+
+# function that runs one diagnostic session and returns a result dict
+
+def run_case(case_id: str) -> dict[str, str]:
+    ...
+    return {"id": case_id, "score": "5"}
+
+case_ids = ["1", "2", "3"]
+results = batch_evaluate(case_ids, run_case, concurrency=4)
+```
+
+You can achieve the same via the CLI:
+
+```bash
+python cli.py batch-eval --db cases.json --rubric rubric.json \
+    --costs costs.csv --output results.csv --concurrency 4
+```
+

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -10,7 +10,7 @@ from .panel import VirtualPanel
 from .decision import DecisionEngine, RuleEngine, LLMEngine
 from .llm_client import LLMClient, OpenAIClient, OllamaClient
 from .orchestrator import Orchestrator
-from .evaluation import Evaluator
+from .evaluation import Evaluator, async_batch_evaluate, batch_evaluate
 from .ingest.convert import convert_directory
 from .ingest.pipeline import run_pipeline, update_dataset
 from .cpt_lookup import lookup_cpt
@@ -71,4 +71,6 @@ __all__ = [
     "ordered_tests_to_fhir",
     "diagnostic_report_to_case",
     "bundle_to_case",
+    "async_batch_evaluate",
+    "batch_evaluate",
 ]

--- a/tasks.yml
+++ b/tasks.yml
@@ -426,6 +426,7 @@ phases:
           Run large-scale case evaluations concurrently to reduce
           turnaround time on shared compute clusters.
         labels: [enhancement, performance]
+        done: true
 
 
       - id: "T40"

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from sdb.evaluation import Evaluator
+from sdb.evaluation import Evaluator, batch_evaluate
 from sdb.judge import Judgement
 
 
@@ -64,3 +64,15 @@ def test_evaluator_correctness_threshold_custom():
     ev2 = Evaluator(judge2, coster, correct_threshold=3)
     result2 = ev2.evaluate("x", "x", [])
     assert not result2.correct
+
+
+def test_async_batch_evaluate():
+    executed: list[str] = []
+
+    def run_case(cid: str) -> dict[str, str]:
+        executed.append(cid)
+        return {"id": cid}
+
+    result = batch_evaluate(["a", "b", "c"], run_case, concurrency=2)
+    assert len(result) == 3
+    assert executed == ["a", "b", "c"]


### PR DESCRIPTION
## Summary
- implement `async_batch_evaluate` and wrapper
- expose new helpers via `sdb.__init__`
- use new helper in CLI `batch-eval` command
- mark T39a done and document async usage
- provide example usage in README and docs
- add unit test

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bcb621f6c832aa80b738e904044f3