### PR TITLE
Add more RuleEngine heuristics

### DIFF
--- a/sdb/decision.py
+++ b/sdb/decision.py
@@ -40,7 +40,9 @@ class RuleEngine(DecisionEngine):
     pain`` and ``rash`` frequently appear early in the narratives but were not
     handled by the initial prototype. As a result, many sessions defaulted to a
     generic ``"viral infection"`` diagnosis. The rules below address these
-    common presentations.
+    common presentations and incorporate additional heuristics for complaints
+    like ``headache`` or ``sore throat``. Combination rules such as ``fever``
+    with ``neck stiffness`` help surface critical tests like lumbar puncture.
     """
 
     DEFAULT_KEYWORD_ACTIONS = {
@@ -52,6 +54,10 @@ class RuleEngine(DecisionEngine):
         "chest pain": (ActionType.TEST, "electrocardiogram"),
         "shortness of breath": (ActionType.TEST, "pulse oximetry"),
         "rash": (ActionType.QUESTION, "rash appearance"),
+        # Additional rules improving diagnostic accuracy
+        "headache": (ActionType.QUESTION, "headache duration"),
+        "sore throat": (ActionType.TEST, "rapid strep test"),
+        "dizziness": (ActionType.TEST, "blood pressure measurement"),
     }
 
     # Multi-keyword rules evaluated before the single keyword lookup. Each set
@@ -61,6 +67,15 @@ class RuleEngine(DecisionEngine):
         frozenset({"fever", "rash"}): (
             ActionType.QUESTION,
             "recent travel history",
+        ),
+        # New combos capturing more complex presentations
+        frozenset({"fever", "neck stiffness"}): (
+            ActionType.TEST,
+            "lumbar puncture",
+        ),
+        frozenset({"weight loss", "night sweats"}): (
+            ActionType.QUESTION,
+            "tuberculosis exposure",
         ),
     }
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -462,6 +462,7 @@ phases:
           - "Analyze common diagnostic misses with the current engine."
           - "Add rules considering more clinical variables."
           - "Document new logic within `RuleEngine`."
+          - "Expand rules to cover headaches, sore throat and dizziness."
         done: true
         acceptance_criteria:
           - "Rule-based accuracy improves by 10%."

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -24,3 +24,35 @@ def test_chest_pain_triggers_ecg():
     action = panel.deliberate("symptoms persist")
     assert action.action_type == ActionType.TEST
     assert action.content == "electrocardiogram"
+
+
+def test_headache_triggers_question():
+    panel = VirtualPanel()
+    panel.deliberate("severe headache since morning")
+    action = panel.deliberate("needs evaluation")
+    assert action.action_type == ActionType.QUESTION
+    assert action.content == "headache duration"
+
+
+def test_sore_throat_triggers_strep_test():
+    panel = VirtualPanel()
+    panel.deliberate("complaining of sore throat")
+    action = panel.deliberate("ongoing discomfort")
+    assert action.action_type == ActionType.TEST
+    assert action.content == "rapid strep test"
+
+
+def test_combo_fever_neck_stiffness_triggers_lp():
+    panel = VirtualPanel()
+    panel.deliberate("high fever noted")
+    action = panel.deliberate("neck stiffness present")
+    assert action.action_type == ActionType.TEST
+    assert action.content == "lumbar puncture"
+
+
+def test_dizziness_triggers_bp_measurement():
+    panel = VirtualPanel()
+    panel.deliberate("reports episodes of dizziness")
+    action = panel.deliberate("further details")
+    assert action.action_type == ActionType.TEST
+    assert action.content == "blood pressure measurement"


### PR DESCRIPTION
## Summary
- expand the rule-based engine with headache, sore throat and dizziness logic
- trigger lumbar puncture for fever with neck stiffness
- add tests for the new heuristics
- document the updated roadmap task

## Testing
- `flake8`
- `pytest tests/test_decision.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd9a46fe0832ab90d41181c17857f