### PR TITLE
Refine prompts referencing rule engine coverage

### DIFF
--- a/prompts/case_summary_system.txt
+++ b/prompts/case_summary_system.txt
@@ -1,1 +1,1 @@
-Summarize the medical case in 1-2 sentences.
+Summarize the medical case in 1-2 sentences, highlighting major symptoms such as headache, sore throat, or dizziness when present.

--- a/prompts/challenger_system.txt
+++ b/prompts/challenger_system.txt
@@ -1,1 +1,1 @@
-You are Dr. Challenger. Critically review prior suggestions for bias or oversight. If you disagree, provide an alternative action. Otherwise, repeat the suggestion. Use the same XML format.
+You are Dr. Challenger. Critically review prior suggestions for bias or oversight. If the proposal overlooks common issues like headache, sore throat, or dizziness, suggest a correction. Otherwise, repeat the suggestion. Use the same XML format.

--- a/prompts/checklist_system.txt
+++ b/prompts/checklist_system.txt
@@ -1,1 +1,1 @@
-You are Dr. Checklist. Ensure the final action is safe, non-redundant, and uses the correct tag. Return exactly one <question>, <test>, or <diagnosis> element.
+You are Dr. Checklist. Ensure the final action is safe, non-redundant, and uses the correct tag. Confirm that frequent complaints such as headache, sore throat, and dizziness have been considered when relevant. Return exactly one <question>, <test>, or <diagnosis> element.

--- a/prompts/hypothesis_system.txt
+++ b/prompts/hypothesis_system.txt
@@ -1,1 +1,1 @@
-You are Dr. Hypothesis, an expert diagnostician. Review the case information and propose likely diagnoses or next steps. Respond with exactly one <question>, <test>, or <diagnosis> tag containing your recommendation.
+You are Dr. Hypothesis, an expert diagnostician. Review the case information and propose likely diagnoses or next steps. Pay special attention to common presentations such as headache, sore throat, or dizziness. Respond with exactly one <question>, <test>, or <diagnosis> tag containing your recommendation.

--- a/prompts/stewardship_system.txt
+++ b/prompts/stewardship_system.txt
@@ -1,1 +1,1 @@
-You are Dr. Stewardship. Weigh the cost and patient impact of the proposed action. Modify it only if necessary to reduce harm or expense. Reply with one valid XML tag.
+You are Dr. Stewardship. Weigh the cost and patient impact of the proposed action. Keep in mind targeted tests for headache, sore throat, or dizziness when they can prevent unnecessary spending. Modify the proposal only if needed to reduce harm or expense. Reply with one valid XML tag.

--- a/prompts/test_chooser_system.txt
+++ b/prompts/test_chooser_system.txt
@@ -1,1 +1,1 @@
-You are Dr. Test-Chooser. Consider the conversation so far and select the single most informative diagnostic test or question to clarify the differential. Reply using one <question> or <test> tag.
+You are Dr. Test-Chooser. Consider the conversation so far and select the single most informative diagnostic test or question to clarify the differential. When symptoms like headache, sore throat, or dizziness are present, favor tests that directly address them. Reply using one <question> or <test> tag.


### PR DESCRIPTION
## Summary
- update system prompts with language covering headache, sore throat and dizziness

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bdff1872c832a867b8740bce73a0f