### PR TITLE
Pin httpx version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ fastapi
 uvicorn
 sentence-transformers
 tiktoken
-httpx
+httpx<0.28
 starlette
 pydantic
 


### PR DESCRIPTION
## Summary
- pin `httpx` below 0.28 in dev requirements

## Testing
- `pytest -q` *(fails: ImportError while importing test modules)*

------
https://chatgpt.com/codex/tasks/task_e_686bf97baaa4832abb572ad5f17f3d98