### PR TITLE
Fix token cleanup on disconnect

### DIFF
--- a/sdb/ui/app.py
+++ b/sdb/ui/app.py
@@ -158,4 +158,5 @@ async def websocket_endpoint(ws: WebSocket) -> None:
                 orchestrator.ordered_tests,
             )
     except WebSocketDisconnect:
+        TOKENS.pop(token, None)
         return


### PR DESCRIPTION
## Summary
- clean up websocket tokens when the connection is closed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bfa9476c0832ab3ba7fa86ccab724