### PR TITLE
Add FHIR export CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,19 @@ python cli.py batch-eval --db cases.json --rubric rubric.json \
     --costs costs.csv --output results.csv --concurrency 4
 ```
 
+### FHIR Session Export
+
+To convert a session transcript and ordered tests into a FHIR Bundle use the
+`fhir-export` subcommand:
+
+```bash
+python cli.py fhir-export transcript.json tests.json --patient-id 123 > bundle.json
+```
+
+The command reads the JSON transcript (list of `[speaker, text]` pairs) and test
+list, then writes a combined FHIR ``Bundle`` to ``stdout`` or the optional
+``--output`` path.
+
 ---
 
 ## Repository Structure


### PR DESCRIPTION
## Summary
- add `fhir-export` command to CLI for writing transcripts and ordered tests as a FHIR bundle
- document the new workflow in README
- test the command via subprocess

## Testing
- `pip install fastapi uvicorn prometheus_client numpy==1.26.4 pydantic requests starlette`
- `pip install httpx`
- `pip install flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c407c1588832a8a0566e734ddc7e7