### PR TITLE
Implement weighted scores in WeightedVoter

### DIFF
--- a/sdb/ensemble.py
+++ b/sdb/ensemble.py
@@ -17,11 +17,40 @@ class DiagnosisResult:
 class WeightedVoter:
     """Aggregate diagnoses using weighted voting."""
 
-    def vote(self, results: Iterable[DiagnosisResult]) -> str:
-        """Return the diagnosis with the highest weighted score."""
+    def vote(
+        self,
+        results: Iterable[DiagnosisResult],
+        *,
+        weights: Sequence[float] | None = None,
+    ) -> str:
+        """Return the diagnosis with the highest weighted score.
+
+        Parameters
+        ----------
+        results:
+            Iterable of ``DiagnosisResult`` objects.
+        weights:
+            Optional sequence of weights corresponding to ``results``.
+
+        Returns
+        -------
+        str
+            The diagnosis with the highest weighted score. Returns an empty
+            string if ``results`` is empty.
+        """
+
+        res_list = list(results)
+        if weights is not None and len(weights) != len(res_list):
+            raise ValueError("weights must match number of results")
+
         scores: dict[str, float] = defaultdict(float)
-        for res in results:
-            scores[res.diagnosis] += res.confidence
+        if weights is None:
+            for res in res_list:
+                scores[res.diagnosis] += res.confidence
+        else:
+            for res, w in zip(res_list, weights):
+                scores[res.diagnosis] += res.confidence * w
+
         if not scores:
             return ""
         return max(scores.items(), key=lambda x: x[1])[0]

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -16,6 +16,13 @@ def test_weighted_voter_selects_highest_score():
     assert voter.vote(results) == "flu"
 
 
+def test_weighted_voter_respects_weights():
+    voter = WeightedVoter()
+    results = [DiagnosisResult("a", 1.0), DiagnosisResult("b", 1.0)]
+    weights = [0.5, 2.0]
+    assert voter.vote(results, weights=weights) == "b"
+
+
 def test_meta_panel_uses_voter():
     mp = MetaPanel()
     results = [DiagnosisResult("a", 1.0), DiagnosisResult("b", 2.0)]


### PR DESCRIPTION
## Summary
- support optional weights in `WeightedVoter.vote`
- add new unit test verifying weighted voting

## Testing
- `pytest -q tests/test_ensemble.py`

------
https://chatgpt.com/codex/tasks/task_e_686c459ab2c8832ab69b032352f92a2b