### PR TITLE
Add Ollama base URL flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ python -m dx0.cli \
 The cross encoder re-scores the top semantic matches so the most relevant
 passages appear first, improving precision.
 
+To run models via a local Ollama server, specify `--llm-provider ollama` and
+optionally set `--ollama-base-url` if the server is not on the default port:
+
+```bash
+python -m dx0.cli \
+  --llm-provider ollama \
+  --ollama-base-url http://localhost:11434 ...
+```
+
 ### SDBench CLI
 
 ```bash

--- a/cli.py
+++ b/cli.py
@@ -85,6 +85,11 @@ def batch_eval_main(argv: list[str]) -> None:
     )
     parser.add_argument("--llm-model", default="gpt-4")
     parser.add_argument(
+        "--ollama-base-url",
+        default="http://localhost:11434",
+        help="Base URL for the Ollama server",
+    )
+    parser.add_argument(
         "--cache",
         action="store_true",
         help="Cache LLM responses",
@@ -165,6 +170,7 @@ def batch_eval_main(argv: list[str]) -> None:
             cache_path = "llm_cache.jsonl" if args.cache else None
             if args.llm_provider == "ollama":
                 client = OllamaClient(
+                    base_url=args.ollama_base_url,
                     cache_path=cache_path,
                     cache_size=args.cache_size,
                 )
@@ -302,6 +308,11 @@ def main() -> None:
         "--llm-model",
         default="gpt-4",
         help="Model name for LLM engine",
+    )
+    parser.add_argument(
+        "--ollama-base-url",
+        default="http://localhost:11434",
+        help="Base URL for the Ollama server",
     )
     parser.add_argument(
         "--cache",
@@ -452,6 +463,7 @@ def main() -> None:
         cache_path = "llm_cache.jsonl" if args.cache else None
         if args.llm_provider == "ollama":
             client = OllamaClient(
+                base_url=args.ollama_base_url,
                 cache_path=cache_path,
                 cache_size=args.cache_size,
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -356,6 +356,72 @@ def test_cli_cross_encoder_flag(monkeypatch, tmp_path):
     assert captured["ce"] == "ce"
 
 
+def test_cli_ollama_base_url(monkeypatch, tmp_path):
+    cases = [{"id": "1", "summary": "s", "full_text": "t"}]
+    case_file = tmp_path / "cases.json"
+    with open(case_file, "w", encoding="utf-8") as f:
+        json.dump(cases, f)
+
+    rubric_file = tmp_path / "r.json"
+    with open(rubric_file, "w", encoding="utf-8") as f:
+        json.dump({}, f)
+
+    cost_file = tmp_path / "c.csv"
+    with open(cost_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["test_name", "cpt_code", "price"],
+        )
+        writer.writeheader()
+        writer.writerow({"test_name": "x", "cpt_code": "1", "price": "1"})
+
+    captured: dict[str, str | None] = {}
+
+    class DummyOllamaClient(LLMClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            captured["url"] = kwargs.get("base_url")
+
+        def _chat(self, messages, model):
+            return None
+
+    monkeypatch.setattr(cli, "OllamaClient", DummyOllamaClient)
+    monkeypatch.setattr(cli, "start_metrics_server", lambda *_: None)
+
+    class DummyOrchestrator:
+        def __init__(self, *args, **kwargs):
+            self.finished = True
+            self.total_time = 0.0
+            self.final_diagnosis = ""
+            self.ordered_tests = []
+
+        def run_turn(self, *_args, **_kwargs):
+            return ""
+
+    monkeypatch.setattr(cli, "Orchestrator", DummyOrchestrator)
+
+    argv = [
+        "cli.py",
+        "--db",
+        str(case_file),
+        "--case",
+        "1",
+        "--rubric",
+        str(rubric_file),
+        "--costs",
+        str(cost_file),
+        "--panel-engine",
+        "llm",
+        "--llm-provider",
+        "ollama",
+        "--ollama-base-url",
+        "http://127.0.0.1:11434",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    cli.main()
+    assert captured["url"] == "http://127.0.0.1:11434"
+
+
 def test_fhir_export_command(tmp_path):
     transcript = [["panel", "hello"], ["gatekeeper", "hi"]]
     tests = ["cbc"]


### PR DESCRIPTION
## Summary
- add `--ollama-base-url` flag in the Dx0 CLI
- pass the base URL when creating `OllamaClient`
- document the flag in `README.md`
- test that the argument is wired through correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_686c6fb706c8832abd2e5001ed2579f6