### PR TITLE
Add fhir-import CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ To append newly released cases without re-downloading the entire corpus, run:
 python scripts/update_cases.py
 ```
 
+To convert a FHIR ``Bundle`` or ``DiagnosticReport`` into SDBench case JSON,
+use the `fhir-import` command:
+
+```bash
+python cli.py fhir-import report.json --case-id new_case > case.json
+```
+
 
 ### Physician UI
 


### PR DESCRIPTION
## Summary
- add `fhir-import` subcommand to convert FHIR bundles or DiagnosticReports to case JSON
- document the command under Data Ingestion
- test the new CLI functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cdfc0095c832a92dfc4c6786837e0