### PR TITLE
Add vote weight parsing for ensemble

### DIFF
--- a/sdb/ensemble.py
+++ b/sdb/ensemble.py
@@ -71,9 +71,18 @@ def cost_adjusted_selection(
 class MetaPanel:
     """Synthesize a final diagnosis from multiple panel runs."""
 
-    def __init__(self, voter: WeightedVoter | None = None):
+    def __init__(
+        self,
+        voter: WeightedVoter | None = None,
+        *,
+        weights: Mapping[str, float] | None = None,
+    ) -> None:
+        """Create a meta panel with an optional voter and weight mapping."""
+
         self.voter = voter or WeightedVoter()
+        self.weights = weights
 
     def synthesize(self, results: Sequence[DiagnosisResult]) -> str:
         """Return the weighted-vote winner from ``results``."""
-        return self.voter.vote(results)
+
+        return self.voter.vote(results, weights=self.weights)


### PR DESCRIPTION
## Summary
- add `--vote-weights` option to cli
- load vote weights from JSON string or file
- pass weights to MetaPanel for diagnosis aggregation

## Testing
- `flake8 cli.py sdb/ensemble.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce5b09a5c832aa0cec4a072d01e5f