### PR TITLE
Add YAML configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ python -m dx0.cli \
   --ollama-base-url http://localhost:11434 ...
 ```
 
+### Configuration
+
+You can load common settings from a YAML file using `--config`:
+
+```yaml
+openai_api_key: sk-your-key
+openai_model: gpt-4
+ollama_base_url: http://localhost:11434
+metrics_port: 8000
+```
+
+Pass the file to any CLI command:
+
+```bash
+python cli.py --config settings.yml --db cases.json --case 1 --rubric r.json --costs c.csv
+```
+
 ### SDBench CLI
 
 ```bash

--- a/cli.py
+++ b/cli.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import sys
+from sdb.config import load_settings, settings
 from sdb import (
     CaseDatabase,
     Gatekeeper,
@@ -53,6 +54,7 @@ def stats_main(argv: list[str]) -> None:
     parser = argparse.ArgumentParser(description="Run significance test")
     parser.add_argument("baseline", help="CSV file for baseline results")
     parser.add_argument("variant", help="CSV file for variant results")
+    parser.add_argument("--config", default=None, help="YAML settings file")
     parser.add_argument(
         "--column",
         default="score",
@@ -65,6 +67,7 @@ def stats_main(argv: list[str]) -> None:
         help="Number of permutations",
     )
     args = parser.parse_args(argv)
+    load_settings(args.config)
 
     a = load_scores(args.baseline, args.column)
     b = load_scores(args.variant, args.column)
@@ -76,6 +79,7 @@ def batch_eval_main(argv: list[str]) -> None:
     """Run evaluations for multiple cases concurrently."""
 
     parser = argparse.ArgumentParser(description="Batch evaluate cases")
+    parser.add_argument("--config", default=None, help="YAML settings file")
     parser.add_argument("--db", help="Path to case JSON, CSV or directory")
     parser.add_argument("--db-sqlite", help="Path to case SQLite database")
     parser.add_argument("--rubric", required=True, help="Scoring rubric JSON")
@@ -198,7 +202,7 @@ def batch_eval_main(argv: list[str]) -> None:
             cache_path = "llm_cache.jsonl" if args.cache else None
             if args.llm_provider == "ollama":
                 client = OllamaClient(
-                    base_url=args.ollama_base_url,
+                    base_url=args.ollama_base_url or settings.ollama_base_url,
                     cache_path=cache_path,
                     cache_size=args.cache_size,
                 )
@@ -337,6 +341,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Run a simple diagnostic session",
     )
+    parser.add_argument("--config", default=None, help="YAML settings file")
     parser.add_argument(
         "--db",
         help="Path to case JSON, CSV or directory",
@@ -477,6 +482,7 @@ def main() -> None:
         help="Port for Prometheus metrics server (default 8000)",
     )
     args = parser.parse_args()
+    load_settings(args.config)
 
     vote_weights = _load_weights(args.vote_weights)
     meta_panel = MetaPanel(weights=vote_weights)
@@ -541,7 +547,7 @@ def main() -> None:
         cache_path = "llm_cache.jsonl" if args.cache else None
         if args.llm_provider == "ollama":
             client = OllamaClient(
-                base_url=args.ollama_base_url,
+                base_url=args.ollama_base_url or settings.ollama_base_url,
                 cache_path=cache_path,
                 cache_size=args.cache_size,
             )

--- a/sdb/config.py
+++ b/sdb/config.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import os
+import yaml
+
+
+@dataclass
+class Settings:
+    """Configuration options loaded from YAML or environment variables."""
+
+    openai_api_key: Optional[str] = None
+    openai_model: str = "gpt-4"
+    ollama_base_url: str = "http://localhost:11434"
+    metrics_port: int = 8000
+    semantic_retrieval: bool = False
+    cross_encoder_model: Optional[str] = None
+
+
+def load_settings(path: str | None = None) -> Settings:
+    """Return :class:`Settings` from ``path`` and environment variables."""
+
+    data: dict[str, object] = {}
+    if path:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    env = os.getenv
+    if "openai_api_key" not in data and env("OPENAI_API_KEY"):
+        data["openai_api_key"] = env("OPENAI_API_KEY")
+    if "openai_model" not in data and env("OPENAI_MODEL"):
+        data["openai_model"] = env("OPENAI_MODEL")
+    if "ollama_base_url" not in data and env("OLLAMA_BASE_URL"):
+        data["ollama_base_url"] = env("OLLAMA_BASE_URL")
+    if "metrics_port" not in data and env("SDB_METRICS_PORT"):
+        try:
+            data["metrics_port"] = int(env("SDB_METRICS_PORT"))
+        except ValueError:
+            pass
+    return Settings(**data)
+
+
+# Global settings instance used by the package
+settings = load_settings()

--- a/sdb/gatekeeper.py
+++ b/sdb/gatekeeper.py
@@ -7,6 +7,7 @@ import re
 import xml.etree.ElementTree as ET
 
 from .protocol import ActionType
+from .config import settings
 
 from .case_database import CaseDatabase
 from .retrieval import SentenceTransformerIndex
@@ -38,7 +39,7 @@ class Gatekeeper:
         self,
         db: CaseDatabase,
         case_id: str,
-        use_semantic_retrieval: bool = False,
+        use_semantic_retrieval: bool | None = None,
         cross_encoder_name: str | None = None,
     ):
         """Bind the gatekeeper to a case and set up test cache.
@@ -52,6 +53,11 @@ class Gatekeeper:
         cross_encoder_name:
             Optional cross-encoder model used to rerank retrieval results.
         """
+
+        if use_semantic_retrieval is None:
+            use_semantic_retrieval = settings.semantic_retrieval
+        if cross_encoder_name is None:
+            cross_encoder_name = settings.cross_encoder_model
 
         self.case = db.get_case(case_id)
         self.known_tests: Dict[str, str] = {}

--- a/sdb/ingest/convert.py
+++ b/sdb/ingest/convert.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional
 
 from ..prompt_loader import load_prompt
 from ..llm_client import OpenAIClient
+from ..config import settings
 
 
 SUMMARY_PROMPT = load_prompt("case_summary_system")
@@ -44,7 +45,7 @@ def _extract_abstract(text: str) -> Optional[str]:
     return None
 
 
-_openai_client = OpenAIClient()
+_openai_client = OpenAIClient(api_key=settings.openai_api_key)
 
 
 def _llm_summarize(text: str) -> Optional[str]:
@@ -55,7 +56,7 @@ def _llm_summarize(text: str) -> Optional[str]:
             {"role": "system", "content": SUMMARY_PROMPT},
             {"role": "user", "content": text[:4000]},
         ],
-        model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
+        model=os.getenv("OPENAI_MODEL", settings.openai_model),
     )
     if reply:
         return reply.strip()

--- a/sdb/llm_client.py
+++ b/sdb/llm_client.py
@@ -8,6 +8,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from typing import List, OrderedDict
+from .config import settings
 
 try:
     import tiktoken  # type: ignore
@@ -134,7 +135,9 @@ class OpenAIClient(LLMClient):
         cache_size: int = 128,
     ) -> None:
         super().__init__(cache_path=cache_path, cache_size=cache_size)
-        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self.api_key = (
+            api_key or settings.openai_api_key or os.getenv("OPENAI_API_KEY")
+        )
 
     def _chat(self, messages: List[dict], model: str) -> str | None:
         if openai is None or not self.api_key:
@@ -159,11 +162,12 @@ class OllamaClient(LLMClient):
 
     def __init__(
         self,
-        base_url: str = "http://localhost:11434",
+        base_url: str | None = None,
         cache_path: str | None = None,
         cache_size: int = 128,
     ) -> None:
         super().__init__(cache_path=cache_path, cache_size=cache_size)
+        base_url = base_url or settings.ollama_base_url
         self.base_url = base_url.rstrip("/")
 
     def _chat(self, messages: List[dict], model: str) -> str | None:

--- a/sdb/metrics.py
+++ b/sdb/metrics.py
@@ -2,6 +2,7 @@
 
 import os
 from prometheus_client import Counter, Histogram, start_http_server
+from .config import settings
 
 ORCHESTRATOR_TURNS = Counter(
     "orchestrator_turns_total", "Number of orchestrator turns executed."
@@ -51,5 +52,8 @@ def start_metrics_server(port: int | None = None) -> None:
 
     if port is None:
         env = os.getenv("SDB_METRICS_PORT")
-        port = int(env) if env else 8000
+        if env:
+            port = int(env)
+        else:
+            port = settings.metrics_port
     start_http_server(port)


### PR DESCRIPTION
## Summary
- introduce `sdb.config.Settings` dataclass with loader
- load settings via new `--config` flag in CLI commands
- use `Settings` defaults in Gatekeeper, LLM clients and metrics
- document YAML configuration usage in README

## Testing
- `pip install pydantic starlette requests PyYAML httpx prometheus_client fastapi uvicorn numpy bcrypt flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d30b01d80832aa24eb66f9ecf2e1a