### PR TITLE
Add asynchronous LLM client

### DIFF
--- a/sdb/orchestrator.py
+++ b/sdb/orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import asyncio
 
 from .panel import VirtualPanel, PanelAction
 from .gatekeeper import Gatekeeper
@@ -73,9 +74,59 @@ class Orchestrator:
         xml = build_action(action.action_type, action.content)
         result = self.gatekeeper.answer_question(xml)
         logger.info(
-            json.dumps(
-                {"event": "gatekeeper_response", "synthetic": result.synthetic}
+            json.dumps({"event": "gatekeeper_response", "synthetic": result.synthetic})
+        )
+
+        if action.action_type == ActionType.TEST:
+            self.ordered_tests.append(action.content)
+            if self.cost_estimator:
+                self.spent += self.cost_estimator.estimate_cost(action.content)
+                if self.budget is not None and self.spent >= self.budget:
+                    self.finished = True
+        logger.info(json.dumps({"event": "spent", "amount": self.spent}))
+        if action.action_type == ActionType.DIAGNOSIS:
+            self.finished = True
+            self.final_diagnosis = action.content
+            logger.info(
+                json.dumps(
+                    {
+                        "event": "final_diagnosis",
+                        "diagnosis": action.content,
+                    }
+                )
             )
+
+        duration = time.perf_counter() - start
+        self.total_time += duration
+        ORCHESTRATOR_LATENCY.observe(duration)
+        return result.content
+
+    async def run_turn_async(self, case_info: str) -> str:
+        """Asynchronous version of :meth:`run_turn`."""
+
+        start = time.perf_counter()
+        if hasattr(self.panel, "adeliberate"):
+            action = await self.panel.adeliberate(case_info=case_info)
+        else:
+            action = await asyncio.to_thread(self.panel.deliberate, case_info)
+        ORCHESTRATOR_TURNS.inc()
+        logger.info(
+            json.dumps(
+                {
+                    "event": "panel_action",
+                    "turn": getattr(self.panel, "turn", 0),
+                    "type": action.action_type.value,
+                    "content": action.content,
+                }
+            )
+        )
+        if self.question_only and action.action_type == ActionType.TEST:
+            action = PanelAction(ActionType.QUESTION, action.content)
+
+        xml = build_action(action.action_type, action.content)
+        result = await asyncio.to_thread(self.gatekeeper.answer_question, xml)
+        logger.info(
+            json.dumps({"event": "gatekeeper_response", "synthetic": result.synthetic})
         )
 
         if action.action_type == ActionType.TEST:

--- a/tasks.yml
+++ b/tasks.yml
@@ -520,6 +520,26 @@ phases:
   epic: Phase 5
   assigned_to: null
 
+- id: 55
+  title: Add Async LLM Client Support
+  description: >
+    Implement asynchronous LLM client and concurrency utilities for batch
+    evaluation.
+  component: backend
+  area: async
+  dependencies: []
+  priority: 4
+  status: done
+  actionable_steps:
+    - Provide `AsyncLLMClient` with async chat method.
+    - Allow `LLMEngine` and helpers to use async clients.
+    - Run LLM calls concurrently during batch evaluation.
+  acceptance_criteria:
+    - "Async batch evaluation functions handle coroutine case runners."
+  command: null
+  epic: Phase 5
+  assigned_to: null
+
 - id: 46
   title: Centralize Application Configuration
   description: >


### PR DESCRIPTION
## Summary
- implement `AsyncLLMClient` for non-blocking LLM calls
- extend `LLMEngine`, `VirtualPanel`, and `Orchestrator` with async methods
- enhance evaluation helpers to handle async case functions
- test async batch evaluation
- track work in tasks.yml

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686d37c67e54832abe447a6b342b0c14