### PR TITLE
Add structlog-based JSON logging

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21,6 +21,7 @@ from sdb import (
     DiagnosisResult,
     MetaPanel,
     batch_evaluate,
+    configure_logging,
     run_pipeline,
     start_metrics_server,
     load_scores,
@@ -164,7 +165,7 @@ def batch_eval_main(argv: list[str]) -> None:
         level = logging.DEBUG
     elif args.quiet:
         level = logging.WARNING
-    logging.basicConfig(level=level, format="%(message)s")
+    configure_logging(level)
 
     if args.db is None and args.db_sqlite is None:
         parser.error("--db or --db-sqlite is required")
@@ -510,7 +511,7 @@ def main() -> None:
         level = logging.DEBUG
     elif args.quiet:
         level = logging.WARNING
-    logging.basicConfig(level=level, format="%(message)s")
+    configure_logging(level)
 
     if args.db_sqlite:
         db = load_from_sqlite(args.db_sqlite)

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,3 +43,9 @@ flow while you chat with the Gatekeeper.
 See `weighted_voter.md` for an overview of how the `WeightedVoter` class
 combines multiple diagnoses using confidence scores and optional run-specific
 weights.
+
+## Structured Logging
+
+Logs are emitted in JSON format. Initialize logging with
+`sdb.configure_logging()` and refer to `logging.md` for examples of consuming
+the output.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,15 @@
+# Structured Logging
+
+Dx0 now emits logs in JSON format using [structlog](https://www.structlog.org/).
+Initialize logging at application start with `sdb.configure_logging()` which
+sets up a JSON renderer and standard timestamp/level fields.
+
+Each log line contains the event name plus keyword attributes. Example:
+
+```json
+{"timestamp": "2024-01-01T00:00:00Z", "level": "info", "event": "panel_action", "turn": 1, "type": "question", "content": "chief complaint"}
+```
+
+These logs can be piped to tools like `jq` or shipped to your log aggregation
+system for analysis.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "prometheus_client",
     "numpy>=1.26.4",
     "sentence-transformers",
+    "structlog",
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ mypy
 pre-commit
 prometheus_client  # Metrics exposure for FastAPI app
 numpy>=1.26.4
+structlog
 fastapi
 uvicorn  # ASGI server for development
 sentence-transformers  # Embedding models for retrieval

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -11,6 +11,7 @@ from .decision import DecisionEngine, RuleEngine, LLMEngine
 from .llm_client import LLMClient, OpenAIClient, OllamaClient
 from .orchestrator import Orchestrator
 from .evaluation import Evaluator, async_batch_evaluate, batch_evaluate
+from .logging_config import configure_logging
 from .ingest.convert import convert_directory
 from .ingest.pipeline import run_pipeline, update_dataset
 from .cpt_lookup import lookup_cpt
@@ -73,4 +74,5 @@ __all__ = [
     "bundle_to_case",
     "async_batch_evaluate",
     "batch_evaluate",
+    "configure_logging",
 ]

--- a/sdb/decision.py
+++ b/sdb/decision.py
@@ -4,8 +4,7 @@ from dataclasses import dataclass
 from typing import List, Set
 from abc import ABC, abstractmethod
 
-import json
-import logging
+import structlog
 import asyncio
 
 from .actions import PanelAction, parse_panel_action
@@ -13,7 +12,7 @@ from .protocol import ActionType
 from .prompt_loader import load_prompt
 from .llm_client import LLMClient, OpenAIClient, AsyncLLMClient
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @dataclass
@@ -168,13 +167,9 @@ class LLMEngine(DecisionEngine):
         if action is None:
             return self.fallback.decide(context)
         logger.info(
-            json.dumps(
-                {
-                    "event": "llm_decision",
-                    "turn": context.turn,
-                    "type": action.action_type.value,
-                }
-            )
+            "llm_decision",
+            turn=context.turn,
+            type=action.action_type.value,
         )
         return action
 
@@ -195,12 +190,8 @@ class LLMEngine(DecisionEngine):
         if action is None:
             return await asyncio.to_thread(self.fallback.decide, context)
         logger.info(
-            json.dumps(
-                {
-                    "event": "llm_decision",
-                    "turn": context.turn,
-                    "type": action.action_type.value,
-                }
-            )
+            "llm_decision",
+            turn=context.turn,
+            type=action.action_type.value,
         )
         return action

--- a/sdb/llm_client.py
+++ b/sdb/llm_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import time
 import json
-import logging
+import structlog
 from abc import ABC, abstractmethod
 from typing import List, OrderedDict
 from .config import settings
@@ -23,7 +23,7 @@ except Exception:  # pragma: no cover - optional dependency
 import requests
 from .metrics import LLM_LATENCY, LLM_TOKENS
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class FileCache:
@@ -95,14 +95,10 @@ class LLMClient(ABC):
         if self.cache and reply is not None:
             self.cache.set(key, reply)
         logger.info(
-            json.dumps(
-                {
-                    "event": "llm_chat",
-                    "model": model,
-                    "latency": duration,
-                    "tokens": tokens,
-                }
-            )
+            "llm_chat",
+            model=model,
+            latency=duration,
+            tokens=tokens,
         )
         return reply
 
@@ -147,14 +143,10 @@ class AsyncLLMClient(ABC):
         if self.cache and reply is not None:
             self.cache.set(key, reply)
         logger.info(
-            json.dumps(
-                {
-                    "event": "llm_chat",
-                    "model": model,
-                    "latency": duration,
-                    "tokens": tokens,
-                }
-            )
+            "llm_chat",
+            model=model,
+            latency=duration,
+            tokens=tokens,
         )
         return reply
 

--- a/sdb/logging_config.py
+++ b/sdb/logging_config.py
@@ -1,0 +1,28 @@
+"""Structured logging configuration using structlog."""
+
+from __future__ import annotations
+
+import logging
+
+import structlog
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure structlog for JSON output.
+
+    Parameters
+    ----------
+    level:
+        Logging level applied to all loggers.
+    """
+
+    logging.basicConfig(level=level, format="%(message)s")
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(level),
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.JSONRenderer(),
+        ],
+    )
+

--- a/sdb/panel.py
+++ b/sdb/panel.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import json
-import logging
+import structlog
 import asyncio
 from typing import List, Set
 
@@ -11,7 +10,7 @@ from .actions import PanelAction
 from .decision import Context, DecisionEngine, RuleEngine
 from .metrics import PANEL_ACTIONS
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class VirtualPanel:
@@ -51,14 +50,10 @@ class VirtualPanel:
         action = self.engine.decide(ctx)
         PANEL_ACTIONS.labels(action.action_type.value).inc()
         logger.info(
-            json.dumps(
-                {
-                    "event": "deliberate",
-                    "turn": self.turn,
-                    "type": action.action_type.value,
-                    "content": action.content,
-                }
-            )
+            "deliberate",
+            turn=self.turn,
+            type=action.action_type.value,
+            content=action.content,
         )
         return action
 
@@ -80,13 +75,9 @@ class VirtualPanel:
             action = await asyncio.to_thread(self.engine.decide, ctx)
         PANEL_ACTIONS.labels(action.action_type.value).inc()
         logger.info(
-            json.dumps(
-                {
-                    "event": "deliberate",
-                    "turn": self.turn,
-                    "type": action.action_type.value,
-                    "content": action.content,
-                }
-            )
+            "deliberate",
+            turn=self.turn,
+            type=action.action_type.value,
+            content=action.content,
         )
         return action


### PR DESCRIPTION
## Summary
- switch to structlog for JSON-formatted logs
- update all modules to use structured logging
- configure logging via new `logging_config` helper
- document how to consume logs
- include structlog in dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xmlschema')*

------
https://chatgpt.com/codex/tasks/task_e_686d40ed19e8832aa9bc12580cb231c1