### PR TITLE
Complete packaging metadata and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ This repository contains two integrated projects for advancing sequential clinic
 
 ## Installation
 
+Full setup instructions are provided in [docs/installation.md](docs/installation.md).
+The short version is:
+
 ```bash
 git clone https://github.com/adrianwedd/Dx0.git
 cd clinical-ai-suite
@@ -47,10 +50,8 @@ source venv/bin/activate
 pip install -r requirements.lock
 ```
 
-See [Dependency Management](docs/dependency_updates.md) for instructions on
-updating and auditing requirements.
-
-*(Optional)* Docker build:
+See [Dependency Management](docs/dependency_updates.md) for details on
+updating and auditing requirements. You can also build a Docker image with:
 
 ```bash
 docker build -t clinical-ai-suite .

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,24 @@ Developers working from a cloned repository can install in editable mode:
 pip install -e .
 ```
 
+## Usage Examples
+
+Run the CLI on a single case in budgeted mode:
+
+```bash
+python -m dx0.cli \
+  --mode budgeted \
+  --case-file data/sdbench/cases/case_001.json \
+  --budget 1000 \
+  --output results/case_001.json
+```
+
+To start the demo web UI locally:
+
+```bash
+uvicorn sdb.ui.app:app --reload
+```
+
 ## Environment Setup
 
 ### Using the OpenAI API

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -23,4 +23,16 @@ Initial public release of the SDB package and Dx0 demo. Highlights:
 - CLI for running sessions and significance tests.
 - Simple FastAPI UI with Prometheus metrics and Grafana dashboard.
 
+## Release Procedure
+
+1. Update the version and changelog sections above.
+2. Ensure all tests pass and the `dist/` directory is clean.
+3. Build the wheel and source archives:
+
+   ```bash
+   python -m build
+   ```
+
+4. Tag the commit and push the archives to your package index.
+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,23 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "sdb"
 version = "0.1.0"
 description = "Sequential diagnosis benchmark and demo orchestrator"
-authors = [{name = "MAI"}]
+authors = [{name = "MAI", email = "maintainers@example.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-license = "MIT"
+license = {file = "LICENSE"}
+keywords = ["diagnosis", "benchmark", "medical ai"]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Intended Audience :: Developers",
+    "Development Status :: 3 - Alpha",
+]
 dependencies = [
     "fastapi",
     "uvicorn",
@@ -33,6 +41,7 @@ sdb-cli = "cli:main"
 [tool.setuptools]
 packages = ["sdb", "sdb.ingest", "sdb.ui", "sdb.plugins"]
 py-modules = ["cli"]
+include-package-data = true
 
 [project.entry-points."dx0.personas"]
 optimist = "sdb.plugins.optimist_plugin:optimistic_chain"


### PR DESCRIPTION
## Summary
- add wheel requirement and metadata in pyproject
- expand installation guide with CLI and UI usage examples
- reference installation doc from README
- document release procedure

## Testing
- `python -m build --sdist --wheel`
- `pytest -q` *(fails: async plugin missing, flake8 missing, persona plugin not found, retrieval issue)*

------
https://chatgpt.com/codex/tasks/task_e_686dbadb26b4832aae25dbe80c6b2235