### PR TITLE
Revise judge scoring and add LLM rubric

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,3 +49,11 @@ weights.
 Logs are emitted in JSON format. Initialize logging with
 `sdb.configure_logging()` and refer to `logging.md` for examples of consuming
 the output.
+
+## Evaluation
+
+Dx0 relies on an LLM-based judge to grade diagnoses on a five-point rubric.
+The system prompt in `prompts/judge_system.txt` explains the scale from 1
+(completely incorrect) to 5 (clinically equivalent). During evaluation the
+model's numeric score is used directly. If no score can be parsed, a default
+rating of 1 is assigned.

--- a/prompts/judge_system.txt
+++ b/prompts/judge_system.txt
@@ -1,7 +1,8 @@
-You are Dr. Judge. Rate how clinically similar a candidate diagnosis is to the ground-truth diagnosis using this rubric:
-1 - completely incorrect or unrelated.
-2 - mostly incorrect with minor overlap.
-3 - partially correct but missing key aspects.
-4 - largely correct but not exact.
-5 - clinically equivalent or an obvious synonym.
-Return only the single digit 1-5.
+You are Dr. Judge. Score how closely a candidate diagnosis matches the
+ground-truth diagnosis using this five-point rubric:
+1 - completely incorrect or unrelated
+2 - mostly incorrect with only minor overlap
+3 - somewhat correct or a vague synonym
+4 - nearly correct but missing important details
+5 - clinically equivalent or an exact synonym
+Respond with just the single digit 1-5.

--- a/sdb/judge.py
+++ b/sdb/judge.py
@@ -1,7 +1,6 @@
-import difflib
 import re
 from dataclasses import dataclass
-from typing import Dict, Any
+from typing import Any, Dict
 
 from .prompt_loader import load_prompt
 from .llm_client import LLMClient, OpenAIClient
@@ -28,8 +27,6 @@ class Judge:
         self.model = model
         self.client = client or OpenAIClient()
         self.prompt = load_prompt("judge_system")
-        self.exact_threshold = float(rubric.get("exact_threshold", 0.9))
-        self.partial_threshold = float(rubric.get("partial_threshold", 0.6))
 
     def _llm_score(self, diagnosis: str, truth: str) -> int | None:
         """Return a Likert score from the LLM or ``None`` on failure."""
@@ -54,21 +51,8 @@ class Judge:
         d = diagnosis.strip()
         t = truth.strip()
         score = self._llm_score(d, t)
-
         if score is None:
-            ratio = difflib.SequenceMatcher(None, d.lower(), t.lower()).ratio()
-            if ratio >= self.exact_threshold:
-                score = 5
-            elif ratio >= self.partial_threshold:
-                score = 4
-            elif d and t and (
-                d.lower() in t.lower() or t.lower() in d.lower()
-            ):
-                score = 3
-            elif ratio > 0.3:
-                score = 2
-            else:
-                score = 1
+            score = 1
 
         explanations = {
             5: "Exact or near exact match",

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -6,10 +6,16 @@ class DummyClient:
         text = messages[-1]["content"].lower()
         if "heart attack" in text and "myocardial infarction" in text:
             return "5"
+        if "type ii" in text and "type 2" in text:
+            return "5"
         if "influenza virus" in text and "influenza" in text:
             return "4"
         if "common cold" in text and "influenza" in text:
             return "2"
+        if "viral pneumonia" in text and "bacterial pneumonia" in text:
+            return "3"
+        if "gastritis" in text and "myocardial infarction" in text:
+            return "1"
         return "1"
 
 
@@ -21,3 +27,17 @@ def test_judge_llm_synonyms():
     assert res.score == 4
     res = j.evaluate("Common cold", "Influenza")
     assert res.score == 2
+
+
+def test_judge_nuanced_synonyms():
+    j = Judge({}, client=DummyClient())
+    res = j.evaluate("Type II diabetes", "Diabetes mellitus type 2")
+    assert res.score == 5
+    res = j.evaluate("Viral pneumonia", "Bacterial pneumonia")
+    assert res.score == 3
+
+
+def test_judge_misdiagnosis():
+    j = Judge({}, client=DummyClient())
+    res = j.evaluate("Gastritis", "Myocardial infarction")
+    assert res.score == 1


### PR DESCRIPTION
## Summary
- rely solely on LLM scoring in `Judge`
- clarify rubric instructions for `judge_system` prompt
- test nuanced synonym and misdiagnosis cases
- explain LLM-based scoring in docs

## Testing
- `pytest -q` *(fails: missing async plugin and flake8 etc.)*


------
https://chatgpt.com/codex/tasks/task_e_686dbce2f344832a8d31a1e4d1cf52b1