### PR TITLE
Remove difflib fallback and add judge error tests

### DIFF
--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -19,6 +19,16 @@ class DummyClient:
         return "1"
 
 
+class FailingClient:
+    def chat(self, messages, model):
+        return None
+
+
+class BadResponseClient:
+    def chat(self, messages, model):
+        return "no score"
+
+
 def test_judge_llm_synonyms():
     j = Judge({}, client=DummyClient())
     res = j.evaluate("heart attack", "myocardial infarction")
@@ -40,4 +50,16 @@ def test_judge_nuanced_synonyms():
 def test_judge_misdiagnosis():
     j = Judge({}, client=DummyClient())
     res = j.evaluate("Gastritis", "Myocardial infarction")
+    assert res.score == 1
+
+
+def test_judge_llm_failure():
+    j = Judge({}, client=FailingClient())
+    res = j.evaluate("foo", "bar")
+    assert res.score == 1
+
+
+def test_judge_bad_response():
+    j = Judge({}, client=BadResponseClient())
+    res = j.evaluate("foo", "bar")
     assert res.score == 1


### PR DESCRIPTION
## Summary
- drop the unused similarity fallback in `Judge`
- make `_llm_score` raise an error when no score is returned
- return a default score if any error occurs
- add tests for failure handling

## Testing
- `pytest tests/test_judge.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_686dc0de2a64832aa339d85e2011c569