### PR TITLE
Add docs on UI user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ clinical-ai-suite/
 * **PULL_REQUEST_TEMPLATE.md**, **ISSUE_TEMPLATE/**: Guidance for contributors.
 * **CODE_OF_CONDUCT.md**: Community norms and reporting procedures.
 * **docs/persona_plugins.md**: How to create and install persona plugins.
+* **docs/add_users.md**: Adding login accounts for the Physician UI.
 
 ---
 

--- a/docs/add_users.md
+++ b/docs/add_users.md
@@ -1,0 +1,29 @@
+# Adding UI Users
+
+The Physician UI validates logins against a YAML file containing bcrypt password hashes. By default the file is `sdb/ui/users.yml`.
+
+## Generating a Hash
+
+Run the snippet below and copy the printed hash into the YAML file.
+
+```bash
+python - <<'PY'
+import bcrypt, getpass
+pw = getpass.getpass("Password: ")
+print(bcrypt.hashpw(pw.encode(), bcrypt.gensalt()).decode())
+PY
+```
+
+## Updating `users.yml`
+
+Edit the `users` mapping in `sdb/ui/users.yml` to add a new entry:
+
+```yaml
+users:
+  physician: "$2b$12$existinghash..."
+  newuser: "$2b$12$generatedhash..."
+```
+
+## Custom Credential Paths
+
+`sdb/ui/app.py` loads credentials from the path specified by the `UI_USERS_FILE` environment variable. Set this variable to use a different YAML file when deploying the UI.


### PR DESCRIPTION
## Summary
- document adding login credentials for the Physician UI
- link the new guide from the main README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_686dd4e969f4832a966f3e0b71cfd335