### PR TITLE
Add API versioning and message validation

### DIFF
--- a/sdb/ui/static/main.js
+++ b/sdb/ui/static/main.js
@@ -23,7 +23,7 @@ function App() {
 
   React.useEffect(() => {
     if (token) {
-      fetch('/tests')
+      fetch('/api/v1/tests')
         .then(res => res.ok ? res.json() : {tests: []})
         .then(data => setAvailableTests(data.tests || []))
         .catch(() => setAvailableTests([]));
@@ -34,7 +34,7 @@ function App() {
     e.preventDefault();
     const user = e.target.user.value;
     const pass = e.target.pass.value;
-    const res = await fetch('/login', {
+    const res = await fetch('/api/v1/login', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({username: user, password: pass})
@@ -44,7 +44,7 @@ function App() {
       setToken(data.token);
       try {
         setLoadingCase(true);
-        const caseRes = await fetch('/case');
+        const caseRes = await fetch('/api/v1/case');
         if (caseRes.ok) {
           const caseData = await caseRes.json();
           setSummary(caseData.summary);
@@ -59,7 +59,7 @@ function App() {
       } finally {
         setLoadingCase(false);
       }
-      const socket = new WebSocket(`ws://${location.host}/ws?token=${data.token}`);
+      const socket = new WebSocket(`ws://${location.host}/api/v1/ws?token=${data.token}`);
       socket.onmessage = (ev) => {
         const d = JSON.parse(ev.data);
         let msgText = '';


### PR DESCRIPTION
## Summary
- add pydantic schemas for API payloads
- prefix REST and websocket endpoints with `/api/v1`
- update UI JavaScript to use new paths
- validate websocket messages against schema
- tweak retrieval scoring logic for tests
- extend tests for versioned paths and schema validation

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686df04b9344832a96fb0617bdd8e1d9