### PR TITLE
Refactor orchestrator to use service classes

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -22,6 +22,7 @@ from .retrieval import (
     SentenceTransformerIndex,
     CrossEncoderReranker,
 )
+from .services import BudgetManager, ResultAggregator
 from .statistics import load_scores, permutation_test
 from .sqlite_db import load_from_sqlite, save_to_sqlite
 from .fhir_export import transcript_to_fhir, ordered_tests_to_fhir
@@ -52,6 +53,8 @@ __all__ = [
     "OllamaClient",
     "VirtualPanel",
     "Orchestrator",
+    "BudgetManager",
+    "ResultAggregator",
     "Evaluator",
     "convert_directory",
     "lookup_cpt",

--- a/sdb/orchestrator.py
+++ b/sdb/orchestrator.py
@@ -9,6 +9,7 @@ from .panel import VirtualPanel, PanelAction
 from .gatekeeper import Gatekeeper
 from .protocol import build_action, ActionType
 from .cost_estimator import CostEstimator
+from .services import BudgetManager, ResultAggregator
 import time
 from .metrics import ORCHESTRATOR_TURNS, ORCHESTRATOR_LATENCY
 
@@ -23,6 +24,9 @@ class Orchestrator:
         cost_estimator: CostEstimator | None = None,
         budget: float | None = None,
         question_only: bool = False,
+        *,
+        budget_manager: BudgetManager | None = None,
+        result_aggregator: ResultAggregator | None = None,
     ):
         """Coordinate panel actions and track test spending.
 
@@ -42,14 +46,36 @@ class Orchestrator:
 
         self.panel = panel
         self.gatekeeper = gatekeeper
-        self.cost_estimator = cost_estimator
-        self.budget = budget
         self.question_only = question_only
-        self.spent = 0.0
-        self.finished = False
-        self.ordered_tests: list[str] = []
-        self.final_diagnosis: str | None = None
+        self.budget_manager = budget_manager or BudgetManager(
+            cost_estimator, budget
+        )
+        self.results = result_aggregator or ResultAggregator()
         self.total_time = 0.0
+
+    @property
+    def spent(self) -> float:
+        """Total money spent on ordered tests."""
+
+        return self.budget_manager.spent
+
+    @property
+    def ordered_tests(self) -> list[str]:
+        """List of tests ordered so far."""
+
+        return self.results.ordered_tests
+
+    @property
+    def final_diagnosis(self) -> str | None:
+        """Diagnosis provided by the panel, if any."""
+
+        return self.results.final_diagnosis
+
+    @property
+    def finished(self) -> bool:
+        """Whether the session has concluded."""
+
+        return self.results.finished or self.budget_manager.over_budget()
 
     def run_turn(self, case_info: str) -> str:
         """Process a single interaction turn with the panel."""
@@ -74,15 +100,13 @@ class Orchestrator:
         )
 
         if action.action_type == ActionType.TEST:
-            self.ordered_tests.append(action.content)
-            if self.cost_estimator:
-                self.spent += self.cost_estimator.estimate_cost(action.content)
-                if self.budget is not None and self.spent >= self.budget:
-                    self.finished = True
+            self.results.record_test(action.content)
+            self.budget_manager.add_test(action.content)
+            if self.budget_manager.over_budget():
+                self.results.finished = True
         logger.info("spent", amount=self.spent)
         if action.action_type == ActionType.DIAGNOSIS:
-            self.finished = True
-            self.final_diagnosis = action.content
+            self.results.record_diagnosis(action.content)
             logger.info("final_diagnosis", diagnosis=action.content)
 
         duration = time.perf_counter() - start
@@ -116,15 +140,13 @@ class Orchestrator:
         )
 
         if action.action_type == ActionType.TEST:
-            self.ordered_tests.append(action.content)
-            if self.cost_estimator:
-                self.spent += self.cost_estimator.estimate_cost(action.content)
-                if self.budget is not None and self.spent >= self.budget:
-                    self.finished = True
+            self.results.record_test(action.content)
+            self.budget_manager.add_test(action.content)
+            if self.budget_manager.over_budget():
+                self.results.finished = True
         logger.info("spent", amount=self.spent)
         if action.action_type == ActionType.DIAGNOSIS:
-            self.finished = True
-            self.final_diagnosis = action.content
+            self.results.record_diagnosis(action.content)
             logger.info("final_diagnosis", diagnosis=action.content)
 
         duration = time.perf_counter() - start

--- a/sdb/services/__init__.py
+++ b/sdb/services/__init__.py
@@ -1,0 +1,6 @@
+"""Auxiliary service classes used by the orchestrator."""
+
+from .budget import BudgetManager
+from .results import ResultAggregator
+
+__all__ = ["BudgetManager", "ResultAggregator"]

--- a/sdb/services/budget.py
+++ b/sdb/services/budget.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from ..cost_estimator import CostEstimator
+
+
+@dataclass
+class BudgetManager:
+    """Track test spending and enforce an optional budget."""
+
+    cost_estimator: Optional[CostEstimator] = None
+    budget: Optional[float] = None
+    spent: float = 0.0
+
+    def add_test(self, test_name: str) -> None:
+        """Record the cost of ``test_name`` using ``cost_estimator``."""
+        if self.cost_estimator:
+            self.spent += self.cost_estimator.estimate_cost(test_name)
+
+    def over_budget(self) -> bool:
+        """Return ``True`` if the budget was exceeded."""
+        return self.budget is not None and self.spent >= self.budget

--- a/sdb/services/results.py
+++ b/sdb/services/results.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+class ResultAggregator:
+    """Collect ordered tests and final diagnosis."""
+
+    def __init__(self) -> None:
+        self.ordered_tests: list[str] = []
+        self.final_diagnosis: str | None = None
+        self.finished: bool = False
+
+    def record_test(self, test_name: str) -> None:
+        """Add ``test_name`` to the ordered test list."""
+        self.ordered_tests.append(test_name)
+
+    def record_diagnosis(self, diagnosis: str) -> None:
+        """Store ``diagnosis`` and mark the session as finished."""
+        self.final_diagnosis = diagnosis
+        self.finished = True

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,27 @@
+from sdb.services import BudgetManager, ResultAggregator
+
+
+class DummyEstimator:
+    def estimate_cost(self, _name: str) -> float:
+        return 5.0
+
+
+def test_budget_manager_over_budget():
+    bm = BudgetManager(DummyEstimator(), budget=9.0)
+    bm.add_test("cbc")
+    assert bm.spent == 5.0
+    assert not bm.over_budget()
+    bm.add_test("bmp")
+    assert bm.spent == 10.0
+    assert bm.over_budget()
+
+
+def test_result_aggregator_records():
+    agg = ResultAggregator()
+    agg.record_test("cbc")
+    agg.record_test("bmp")
+    assert agg.ordered_tests == ["cbc", "bmp"]
+    assert not agg.finished
+    agg.record_diagnosis("flu")
+    assert agg.final_diagnosis == "flu"
+    assert agg.finished


### PR DESCRIPTION
## Summary
- add `BudgetManager` and `ResultAggregator` service classes
- refactor `Orchestrator` to delegate budgeting and result collection
- expose services from package
- test new service classes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_686df85a4264832ab895aa504c80b997