### PR TITLE
Enable parallel persona prompts

### DIFF
--- a/sdb/config.py
+++ b/sdb/config.py
@@ -17,6 +17,7 @@ class Settings:
     cross_encoder_model: Optional[str] = None
     case_db: Optional[str] = None
     case_db_sqlite: Optional[str] = None
+    parallel_personas: bool = False
 
 
 def load_settings(path: str | None = None) -> Settings:
@@ -42,6 +43,8 @@ def load_settings(path: str | None = None) -> Settings:
         data["case_db"] = env("SDB_CASE_DB")
     if "case_db_sqlite" not in data and env("SDB_CASE_DB_SQLITE"):
         data["case_db_sqlite"] = env("SDB_CASE_DB_SQLITE")
+    if "parallel_personas" not in data and env("SDB_PARALLEL_PERSONAS"):
+        data["parallel_personas"] = env("SDB_PARALLEL_PERSONAS").lower() == "true"
     settings_obj = Settings(**data)
     globals()["settings"] = settings_obj
     return settings_obj

--- a/tasks.yml
+++ b/tasks.yml
@@ -525,6 +525,28 @@ phases:
   assigned_to: null
 
 - id: 65
+  title: Parallel Persona Execution in LLM Engine
+  description: >
+    Allow the LLMEngine to query all persona prompts concurrently when using an
+    AsyncLLMClient.
+  component: panel
+  area: performance
+  dependencies: [47]
+  priority: 3
+  status: done
+  actionable_steps:
+    - Add configuration flag `parallel_personas`.
+    - Dispatch persona prompts concurrently when enabled.
+    - Ensure responses are ordered deterministically.
+    - Write unit tests covering the parallel path.
+  acceptance_criteria:
+    - "adecide executes persona prompts concurrently with AsyncLLMClient."
+    - "Tests validate concurrency and correct action parsing."
+  command: null
+  epic: Phase 5
+  assigned_to: null
+
+- id: 65
   title: Use SQLite for Lazy Case Loading
   description: >
     Implement a SQLite-backed case database and migration script so large

--- a/tests/test_llm_engine_async.py
+++ b/tests/test_llm_engine_async.py
@@ -1,0 +1,57 @@
+import asyncio
+import pytest
+
+from sdb.decision import LLMEngine, Context
+from sdb.protocol import ActionType
+from sdb.llm_client import AsyncLLMClient
+
+
+class CountingClient(AsyncLLMClient):
+    def __init__(self):
+        super().__init__()
+        self.active = 0
+        self.max_active = 0
+
+    async def _chat(self, messages, model):
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        await asyncio.sleep(0.01)
+        self.active -= 1
+        return "<test>done</test>"
+
+
+@pytest.mark.asyncio
+async def test_parallel_personas_concurrent():
+    client = CountingClient()
+    engine = LLMEngine(client=client, parallel_personas=True)
+    ctx = Context(turn=1, past_infos=["info"], triggered_keywords=set())
+    action = await engine.adecide(ctx)
+    assert action.action_type == ActionType.TEST
+    assert client.max_active > 1
+
+
+class LabelClient(AsyncLLMClient):
+    async def _chat(self, messages, model):
+        system = messages[0]["content"]
+        if "Hypothesis" in system:
+            return "<test>1</test>"
+        if "Test-Chooser" in system:
+            return "<test>2</test>"
+        if "Challenger" in system:
+            return "<test>3</test>"
+        if "Stewardship" in system:
+            return "<test>4</test>"
+        if "Checklist" in system:
+            return "<test>5</test>"
+        return "<test>x</test>"
+
+
+@pytest.mark.asyncio
+async def test_parallel_personas_order():
+    engine = LLMEngine(client=LabelClient(), parallel_personas=True)
+    ctx = Context(turn=1, past_infos=["case"], triggered_keywords=set())
+    action = await engine.adecide(ctx)
+    assert action.action_type == ActionType.TEST
+    assert action.content == "5"
+
+


### PR DESCRIPTION
## Summary
- add `parallel_personas` option to Settings
- allow `LLMEngine` to execute persona prompts concurrently
- document new capability in tasks list
- test async parallel execution of persona prompts

## Testing
- `pytest tests/test_llm_engine_async.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686dff28090c832a90b12d001eca26f8