### PR TITLE
Improve error handling in core utilities

### DIFF
--- a/sdb/gatekeeper.py
+++ b/sdb/gatekeeper.py
@@ -80,15 +80,30 @@ class Gatekeeper:
             )
 
     def load_results_from_json(self, path: str) -> None:
-        """Load test result fixtures from a JSON file."""
+        """Load test result fixtures from a JSON file.
+
+        Parameters
+        ----------
+        path:
+            File path containing a mapping of test names to results.
+
+        Raises
+        ------
+        FileNotFoundError
+            If ``path`` does not exist.
+        ValueError
+            If the file cannot be parsed or does not contain a JSON object.
+        """
 
         if not os.path.exists(path):
-            return
+            raise FileNotFoundError(f"Results file not found: {path}")
         try:
             with open(path, "r", encoding="utf-8") as fh:
                 data = json.load(fh)
-        except json.JSONDecodeError:
-            return
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON data in {path}") from exc
+        if not isinstance(data, dict):
+            raise ValueError("Results JSON must be a mapping of test names to results")
         for name, result in data.items():
             self.register_test_result(name, str(result))
 

--- a/tests/test_cost_estimator.py
+++ b/tests/test_cost_estimator.py
@@ -90,3 +90,9 @@ def test_coverage_check(tmp_path):
             cms_pricing_path=str(cms_path),
             coverage_threshold=0.98,
         )
+
+
+def test_lookup_cost_missing():
+    ce = CostEstimator({})
+    with pytest.raises(KeyError):
+        ce.lookup_cost("unknown")

--- a/tests/test_gatekeeper.py
+++ b/tests/test_gatekeeper.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 from sdb.case_database import Case, CaseDatabase
 from sdb.gatekeeper import Gatekeeper
@@ -38,10 +39,8 @@ def test_missing_fixture_file(tmp_path):
     case = Case(id="1", summary="s", full_text="f")
     db = CaseDatabase([case])
     gk = Gatekeeper(db, "1")
-    gk.load_results_from_json(str(tmp_path / "missing.json"))
-    q = build_action(ActionType.TEST, "cbc")
-    res = gk.answer_question(q)
-    assert res.synthetic is True
+    with pytest.raises(FileNotFoundError):
+        gk.load_results_from_json(str(tmp_path / "missing.json"))
 
 
 def test_question():
@@ -127,7 +126,7 @@ def test_unknown_xml_tag():
 
 
 def test_load_results_from_invalid_json(tmp_path):
-    """Malformed JSON fixtures should be ignored without crashing."""
+    """Malformed JSON fixtures should raise a ``ValueError``."""
     case = Case(id="1", summary="s", full_text="f")
     db = CaseDatabase([case])
     gk = Gatekeeper(db, "1")
@@ -135,9 +134,8 @@ def test_load_results_from_invalid_json(tmp_path):
     path = tmp_path / "bad.json"
     path.write_text("{invalid}", encoding="utf-8")
 
-    gk.load_results_from_json(str(path))
-    res = gk.answer_question(build_action(ActionType.TEST, "cbc"))
-    assert res.synthetic is True
+    with pytest.raises(ValueError):
+        gk.load_results_from_json(str(path))
 
 
 def test_unexpected_nested_xml():


### PR DESCRIPTION
## Summary
- raise explicit errors when fixture files are missing or invalid
- raise `KeyError` from `CostEstimator.lookup_cost` when a test is unknown
- document new exceptions
- update unit tests for new behaviour

## Testing
- `pytest -k "lookup_cost_missing" -q` *(fails: ModuleNotFoundError: No module named 'starlette')*

------
https://chatgpt.com/codex/tasks/task_e_686e0407a1f8832aa0e6c537d50e78a7