### PR TITLE
Refactor Settings with Pydantic validation

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,20 @@
+import yaml
+import pytest
+
+from sdb.config import load_settings
+
+
+def test_invalid_metrics_port(tmp_path):
+    cfg_path = tmp_path / "settings.yml"
+    with open(cfg_path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump({"metrics_port": 70000}, fh)
+    with pytest.raises(ValueError):
+        load_settings(str(cfg_path))
+
+
+def test_invalid_base_url(tmp_path):
+    cfg_path = tmp_path / "settings.yml"
+    with open(cfg_path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump({"ollama_base_url": "not a url"}, fh)
+    with pytest.raises(ValueError):
+        load_settings(str(cfg_path))


### PR DESCRIPTION
## Summary
- use a Pydantic `Settings` model with a metrics port validator
- validate config data and raise descriptive errors
- add regression tests for invalid config files

## Testing
- `pytest tests/test_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e114fba00832aa4a2c72cf8a11e1b