### PR TITLE
Add SQLite documentation and code style fixes

### DIFF
--- a/docs/batch_eval.md
+++ b/docs/batch_eval.md
@@ -22,5 +22,9 @@ You can achieve the same via the CLI:
 ```bash
 python cli.py batch-eval --db cases.json --rubric rubric.json \
     --costs costs.csv --output results.csv --concurrency 4
+
+# or with a SQLite database
+python cli.py batch-eval --db-sqlite cases.db --rubric rubric.json \
+    --costs costs.csv --output results.csv --concurrency 4
 ```
 

--- a/docs/dataset_format.md
+++ b/docs/dataset_format.md
@@ -22,3 +22,15 @@ Example:
 
 The ingestion pipeline in `sdb.ingest.convert` can convert raw text files into
 this JSON structure.
+
+## SQLite Storage
+
+Cases can also be stored in a SQLite database for lazy loading. Use the
+``scripts/migrate_to_sqlite.py`` script to convert an existing JSON or CSV
+dataset:
+
+```bash
+python scripts/migrate_to_sqlite.py cases.json cases.db
+```
+
+Then load it with ``--db-sqlite`` when running ``cli.py``.

--- a/sdb/case_database.py
+++ b/sdb/case_database.py
@@ -152,4 +152,3 @@ class SQLiteCaseDatabase:
         if row is None:
             raise KeyError(case_id)
         return Case(id=case_id, summary=row[0], full_text=row[1])
-

--- a/sdb/decision.py
+++ b/sdb/decision.py
@@ -142,7 +142,9 @@ class LLMEngine(DecisionEngine):
         self.fallback = RuleEngine()
         self.personas = personas or self.DEFAULT_PERSONAS
         self.parallel_personas = (
-            settings.parallel_personas if parallel_personas is None else parallel_personas
+            settings.parallel_personas
+            if parallel_personas is None
+            else parallel_personas
         )
         self.prompts = {name: load_prompt(name) for name in self.personas}
         for name, text in self.prompts.items():

--- a/sdb/ui/session_db.py
+++ b/sdb/ui/session_db.py
@@ -17,15 +17,28 @@ class SessionDB:
     def _init_db(self) -> None:
         with self._connect() as conn:
             conn.execute(
-                "CREATE TABLE IF NOT EXISTS sessions (token TEXT PRIMARY KEY, username TEXT NOT NULL, issue_time REAL NOT NULL)"
+                (
+                    "CREATE TABLE IF NOT EXISTS sessions "
+                    "(token TEXT PRIMARY KEY, "
+                    "username TEXT NOT NULL, "
+                    "issue_time REAL NOT NULL)"
+                )
             )
             conn.commit()
 
-    def add(self, token: str, username: str, issue_time: Optional[float] = None) -> None:
+    def add(
+        self,
+        token: str,
+        username: str,
+        issue_time: Optional[float] = None,
+    ) -> None:
         ts = issue_time if issue_time is not None else time.time()
         with self._connect() as conn:
             conn.execute(
-                "INSERT OR REPLACE INTO sessions (token, username, issue_time) VALUES (?, ?, ?)",
+                (
+                    "INSERT OR REPLACE INTO sessions "
+                    "(token, username, issue_time) VALUES (?, ?, ?)"
+                ),
                 (token, username, ts),
             )
             conn.commit()

--- a/tests/test_llm_engine_async.py
+++ b/tests/test_llm_engine_async.py
@@ -53,5 +53,3 @@ async def test_parallel_personas_order():
     action = await engine.adecide(ctx)
     assert action.action_type == ActionType.TEST
     assert action.content == "5"
-
-

--- a/tests/test_sqlite_case_database.py
+++ b/tests/test_sqlite_case_database.py
@@ -43,4 +43,3 @@ def test_lazy_memory_usage(tmp_path):
     _ = db.get_case("0")
     after = proc.memory_info().rss
     assert after - before < 1024 * 1024
-

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -277,4 +277,3 @@ async def test_token_cleanup(tmp_path):
     await asyncio.sleep(1.2)
     store.cleanup()
     assert store.get("tok") is None
-


### PR DESCRIPTION
## Summary
- document SQLite storage use and migration
- mention `--db-sqlite` CLI option in batch eval docs
- fix style issues flagged by flake8

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q psutil xmlschema httpx_ws pytest-asyncio`
- `pip install -e . -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e1693a8b0832a9a0b5b5c66a05dd9