### PR TITLE
Add dev dependency installer script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.lock
+          ./scripts/install_dev_deps.sh
       - name: Run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files
       - name: Run tests

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -119,3 +119,13 @@ The screenshot file is base64 encoded. Decode it with:
 ```bash
 base64 -d docs/images/ui.png.b64 > ui.png
 ```
+
+## Testing
+
+Install the development dependencies and run the test suite:
+
+```bash
+./scripts/install_dev_deps.sh
+pytest -q
+```
+

--- a/scripts/install_dev_deps.sh
+++ b/scripts/install_dev_deps.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Install development dependencies listed in requirements.lock
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+cd "$repo_root"
+
+pip install -r requirements.lock


### PR DESCRIPTION
## Summary
- install dependencies via new script
- update docs with testing instructions
- invoke installer in CI

## Testing
- `./scripts/install_dev_deps.sh -q` *(fails: ModuleNotFoundError: No module named 'starlette')*
- `pytest -q` *(fails: 31 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_686e23ae6850832a83bc1943db919228