### PR TITLE
Add API version prefix

### DIFF
--- a/sdb/ui/app.py
+++ b/sdb/ui/app.py
@@ -192,7 +192,7 @@ async def start_cleanup() -> None:
     asyncio.create_task(_loop())
 
 
-@app.get("/", response_class=HTMLResponse)
+@app.get("/api/v1", response_class=HTMLResponse)
 async def index() -> HTMLResponse:
     """Return the React chat application."""
 
@@ -256,7 +256,7 @@ async def websocket_endpoint(ws: WebSocket) -> None:
         while True:
             try:
                 data = await ws.receive_json()
-                msg = ChatMessage.parse_obj(data)
+                msg = ChatMessage.model_validate(data)
             except (ValueError, ValidationError):
                 await ws.close(code=1003)
                 return

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -62,7 +62,7 @@ async def test_websocket_chat():
 
 def test_index_layout():
     client = TestClient(app)
-    res = client.get("/")
+    res = client.get("/api/v1")
     html = res.text
     assert "summary-panel" in html
     assert "tests-panel" in html
@@ -76,6 +76,13 @@ def test_case_summary():
     res = client.get("/api/v1/case")
     assert res.status_code == 200
     assert res.json() == {"summary": "A 30 year old with cough"}
+
+
+def test_unknown_version():
+    """Requests to an unsupported API version return 404."""
+    client = TestClient(app)
+    res = client.get("/api/v2/case")
+    assert res.status_code == 404
 
 
 def test_login_success():
@@ -95,6 +102,13 @@ def test_login_failure():
         json={"username": "physician", "password": "wrong"},
     )
     assert res.status_code == 401
+
+
+def test_login_missing_field():
+    """Missing fields should trigger validation error."""
+    client = TestClient(app)
+    res = client.post("/api/v1/login", json={"username": "physician"})
+    assert res.status_code == 422
 
 
 def test_login_lockout(monkeypatch):


### PR DESCRIPTION
## Summary
- namespace the Physician UI under `/api/v1`
- validate websocket payloads with Pydantic `model_validate`
- update tests for versioned paths and add 404/validation checks

## Testing
- `pytest tests/test_ui.py::test_index_layout tests/test_ui.py::test_unknown_version tests/test_ui.py::test_login_missing_field -q`


------
https://chatgpt.com/codex/tasks/task_e_686e26e69488832ab159a63357dff714