### PR TITLE
Introduce BudgetTracker for orchestrator

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -23,6 +23,7 @@ from .retrieval import (
     CrossEncoderReranker,
 )
 from .services import BudgetManager, ResultAggregator
+from .budget import BudgetTracker
 from .statistics import load_scores, permutation_test
 from .sqlite_db import load_from_sqlite, save_to_sqlite
 from .fhir_export import transcript_to_fhir, ordered_tests_to_fhir
@@ -55,6 +56,7 @@ __all__ = [
     "VirtualPanel",
     "Orchestrator",
     "BudgetManager",
+    "BudgetTracker",
     "ResultAggregator",
     "Evaluator",
     "convert_directory",

--- a/sdb/budget.py
+++ b/sdb/budget.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .cost_estimator import CostEstimator
+
+
+@dataclass
+class BudgetTracker:
+    """Accumulate spending on ordered tests and enforce a limit."""
+
+    cost_estimator: Optional[CostEstimator] = None
+    budget: Optional[float] = None
+    spent: float = 0.0
+
+    def add(self, test_name: str) -> None:
+        """Add the cost of ``test_name`` to the total spent."""
+
+        if self.cost_estimator:
+            self.spent += self.cost_estimator.estimate_cost(test_name)
+
+    def over_budget(self) -> bool:
+        """Return ``True`` if ``spent`` exceeds ``budget``."""
+
+        return self.budget is not None and self.spent >= self.budget

--- a/sdb/orchestrator.py
+++ b/sdb/orchestrator.py
@@ -8,8 +8,8 @@ import asyncio
 from .panel import VirtualPanel, PanelAction
 from .gatekeeper import Gatekeeper
 from .protocol import build_action, ActionType
-from .cost_estimator import CostEstimator
-from .services import BudgetManager, ResultAggregator
+from .budget import BudgetTracker
+from .services import ResultAggregator
 import time
 from .metrics import ORCHESTRATOR_TURNS, ORCHESTRATOR_LATENCY
 
@@ -21,11 +21,9 @@ class Orchestrator:
         self,
         panel: VirtualPanel,
         gatekeeper: Gatekeeper,
-        cost_estimator: CostEstimator | None = None,
-        budget: float | None = None,
         question_only: bool = False,
         *,
-        budget_manager: BudgetManager | None = None,
+        budget_tracker: BudgetTracker | None = None,
         result_aggregator: ResultAggregator | None = None,
     ):
         """Coordinate panel actions and track test spending.
@@ -36,20 +34,16 @@ class Orchestrator:
             :class:`VirtualPanel` generating actions.
         gatekeeper:
             Interface used to obtain answers from the case.
-        cost_estimator:
-            Optional :class:`CostEstimator` for test pricing.
-        budget:
-            Optional maximum spend allowed for tests.
         question_only:
             If ``True``, convert test requests into questions.
+        budget_tracker:
+            Optional :class:`BudgetTracker` tracking test costs.
         """
 
         self.panel = panel
         self.gatekeeper = gatekeeper
         self.question_only = question_only
-        self.budget_manager = budget_manager or BudgetManager(
-            cost_estimator, budget
-        )
+        self.budget_tracker = budget_tracker or BudgetTracker()
         self.results = result_aggregator or ResultAggregator()
         self.total_time = 0.0
 
@@ -57,7 +51,7 @@ class Orchestrator:
     def spent(self) -> float:
         """Total money spent on ordered tests."""
 
-        return self.budget_manager.spent
+        return self.budget_tracker.spent
 
     @property
     def ordered_tests(self) -> list[str]:
@@ -75,7 +69,7 @@ class Orchestrator:
     def finished(self) -> bool:
         """Whether the session has concluded."""
 
-        return self.results.finished or self.budget_manager.over_budget()
+        return self.results.finished or self.budget_tracker.over_budget()
 
     def run_turn(self, case_info: str) -> str:
         """Process a single interaction turn with the panel."""
@@ -101,8 +95,8 @@ class Orchestrator:
 
         if action.action_type == ActionType.TEST:
             self.results.record_test(action.content)
-            self.budget_manager.add_test(action.content)
-            if self.budget_manager.over_budget():
+            self.budget_tracker.add(action.content)
+            if self.budget_tracker.over_budget():
                 self.results.finished = True
         logger.info("spent", amount=self.spent)
         if action.action_type == ActionType.DIAGNOSIS:
@@ -141,8 +135,8 @@ class Orchestrator:
 
         if action.action_type == ActionType.TEST:
             self.results.record_test(action.content)
-            self.budget_manager.add_test(action.content)
-            if self.budget_manager.over_budget():
+            self.budget_tracker.add(action.content)
+            if self.budget_tracker.over_budget():
                 self.results.finished = True
         logger.info("spent", amount=self.spent)
         if action.action_type == ActionType.DIAGNOSIS:

--- a/sdb/ui/app.py
+++ b/sdb/ui/app.py
@@ -23,6 +23,7 @@ from sdb.case_database import Case, CaseDatabase
 from sdb.cost_estimator import CostEstimator, CptCost
 from sdb.gatekeeper import Gatekeeper
 from sdb.orchestrator import Orchestrator
+from sdb.budget import BudgetTracker
 from sdb.panel import PanelAction
 from sdb.protocol import ActionType
 from sdb.ui.session_db import SessionDB
@@ -251,7 +252,11 @@ async def websocket_endpoint(ws: WebSocket) -> None:
         return
     await ws.accept()
     panel = UserPanel()
-    orchestrator = Orchestrator(panel, gatekeeper, cost_estimator=cost_estimator)
+    orchestrator = Orchestrator(
+        panel,
+        gatekeeper,
+        budget_tracker=BudgetTracker(cost_estimator),
+    )
     try:
         while True:
             try:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import pytest
 
 from sdb.orchestrator import Orchestrator
+from sdb.budget import BudgetTracker
 from sdb.panel import VirtualPanel
 from sdb.actions import PanelAction
 from sdb.protocol import ActionType
@@ -73,11 +74,11 @@ def test_orchestrator_budget_stops_session():
         PanelAction(ActionType.DIAGNOSIS, "flu"),
     ]
     panel = StubPanel(actions)
+    tracker = BudgetTracker(DummyCostEstimator(), budget=7.0)
     orch = Orchestrator(
         panel,
         DummyGatekeeper(),
-        cost_estimator=DummyCostEstimator(),
-        budget=7.0,
+        budget_tracker=tracker,
     )
 
     orch.run_turn("1")


### PR DESCRIPTION
## Summary
- add new `BudgetTracker` helper for cost tracking
- refactor `Orchestrator` to use the tracker
- update UI and tests to instantiate the tracker

## Testing
- `pytest tests/test_orchestrator.py -q` *(fails: ModuleNotFoundError: No module named 'xmlschema')*

------
https://chatgpt.com/codex/tasks/task_e_686e3531d3d8832a8fa6b37e3120ca29