### PR TITLE
Enable lazy SQLite loading

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -175,7 +175,7 @@ def batch_eval_main(argv: list[str]) -> None:
         parser.error("--db or --db-sqlite is required")
 
     if args.db_sqlite:
-        db = load_from_sqlite(args.db_sqlite)
+        db = load_from_sqlite(args.db_sqlite, lazy=True)
     elif os.path.isdir(args.db):
         db = CaseDatabase.load_from_directory(args.db)
     elif args.db.endswith(".csv"):
@@ -521,7 +521,7 @@ def main() -> None:
     configure_logging(level)
 
     if args.db_sqlite:
-        db = load_from_sqlite(args.db_sqlite)
+        db = load_from_sqlite(args.db_sqlite, lazy=True)
     elif os.path.isdir(args.db):
         db = CaseDatabase.load_from_directory(args.db)
     elif args.db.endswith(".csv"):

--- a/sdb/case_database.py
+++ b/sdb/case_database.py
@@ -129,6 +129,26 @@ class CaseDatabase:
             )
         return CaseDatabase(cases)
 
+    @staticmethod
+    def load_from_sqlite(path: str, lazy: bool = False):
+        """Load cases from a SQLite database.
+
+        Parameters
+        ----------
+        path:
+            Path to the SQLite database file.
+        lazy:
+            If ``True``, return :class:`SQLiteCaseDatabase` for on-demand
+            retrieval of cases.
+        """
+
+        if lazy:
+            return SQLiteCaseDatabase(path)
+
+        from .sqlite_db import iter_sqlite_cases
+
+        return CaseDatabase(iter_sqlite_cases(path))
+
 
 class SQLiteCaseDatabase:
     """Case storage backed by SQLite with lazy loading."""

--- a/tests/test_case_database.py
+++ b/tests/test_case_database.py
@@ -2,6 +2,8 @@ import csv
 import json
 import tempfile
 
+from sdb.sqlite_db import save_to_sqlite
+
 from sdb.case_database import CaseDatabase
 
 
@@ -38,3 +40,12 @@ def test_load_from_directory(tmp_path):
     (case_dir / "full.txt").write_text("ff")
     db = CaseDatabase.load_from_directory(tmp_path)
     assert db.get_case("4").full_text == "ff"
+
+
+def test_load_from_sqlite_lazy(tmp_path):
+    path = tmp_path / "cases.db"
+    cases = [{"id": "5", "summary": "s", "full_text": "f"}]
+    save_to_sqlite(str(path), cases)
+    db = CaseDatabase.load_from_sqlite(str(path), lazy=True)
+    assert db.get_case("5").summary == "s"
+    assert "cases" not in db.__dict__

--- a/tests/test_sqlite_db.py
+++ b/tests/test_sqlite_db.py
@@ -1,4 +1,8 @@
-from sdb.sqlite_db import save_to_sqlite, load_from_sqlite
+from sdb.sqlite_db import (
+    save_to_sqlite,
+    load_from_sqlite,
+    iter_sqlite_cases,
+)
 
 
 def test_save_and_load(tmp_path):
@@ -7,3 +11,14 @@ def test_save_and_load(tmp_path):
     save_to_sqlite(str(path), cases)
     db = load_from_sqlite(str(path))
     assert db.get_case("1").full_text == "t"
+
+
+def test_iter_sqlite_cases(tmp_path):
+    path = tmp_path / "cases.db"
+    cases = [
+        {"id": "1", "summary": "s1", "full_text": "t1"},
+        {"id": "2", "summary": "s2", "full_text": "t2"},
+    ]
+    save_to_sqlite(str(path), cases)
+    ids = [c.id for c in iter_sqlite_cases(str(path))]
+    assert ids == ["1", "2"]


### PR DESCRIPTION
## Summary
- add `iter_sqlite_cases` generator
- lazily load SQLite databases via `load_from_sqlite(..., lazy=True)`
- allow `CaseDatabase` to load lazily from SQLite
- support lazy SQLite in CLI
- test lazy loading for SQLite functions and `CaseDatabase`

## Testing
- `pip install -q -r requirements.lock`
- `pip install -q xmlschema`
- `pip install -q httpx_ws`
- `pytest tests/test_case_database.py tests/test_sqlite_db.py -q`
- `pytest -q` *(fails: tests/test_accessibility.py::test_roles_and_focus_styles)*

------
https://chatgpt.com/codex/tasks/task_e_686e38a240e0832a9b5ad0b88ffc9c40