### PR TITLE
Ensure services package is packaged

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ cli = ["httpx"]
 sdb-cli = "cli:main"
 
 [tool.setuptools]
-packages = ["sdb", "sdb.ingest", "sdb.ui", "sdb.plugins"]
+packages = ["sdb", "sdb.ingest", "sdb.ui", "sdb.plugins", "sdb.services"]
 py-modules = ["cli"]
 include-package-data = true
 

--- a/sdb/sqlite_db.py
+++ b/sdb/sqlite_db.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
-from typing import Dict, Iterable, Iterator, List
+from typing import Dict, Iterable, Iterator
 
 from .case_database import Case, CaseDatabase, SQLiteCaseDatabase
 

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -10,7 +10,7 @@ def test_roles_and_focus_styles():
     """Static assets include ARIA roles and focus styling."""
 
     client = TestClient(app)
-    res = client.get("/")
+    res = client.get("/api/v1")
     html = res.text
     assert ":focus" in html
     js_path = Path("sdb/ui/static/main.js")


### PR DESCRIPTION
## Summary
- include `sdb.services` in setuptools package list
- fix flake8 complaint in `sqlite_db.py`
- adjust accessibility test to use the correct API path

## Testing
- `pytest -q`
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_686e46813920832abcaab599144c09d3