### PR TITLE
Update CMS pricing updater

### DIFF
--- a/.github/workflows/update_pricing.yml
+++ b/.github/workflows/update_pricing.yml
@@ -2,7 +2,7 @@ name: Update CMS Pricing
 
 on:
   schedule:
-    - cron: '0 6 1 * *'
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 jobs:

--- a/scripts/update_cms_pricing.py
+++ b/scripts/update_cms_pricing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import datetime
 import io
 import os
 import zipfile
@@ -11,10 +12,17 @@ from typing import Dict
 
 import requests
 
-DEFAULT_URL = os.getenv(
-    "CMS_PRICING_URL",
-    "https://download.cms.gov/MedicareClinicalLabFeeSched/20CLAB.zip",
-)
+
+def default_cms_url() -> str:
+    """Return the CMS pricing ZIP URL for the current year."""
+    year = datetime.date.today().year
+    return (
+        "https://download.cms.gov/MedicareClinicalLabFeeSched/"
+        f"{str(year)[-2:]}CLAB.zip"
+    )
+
+
+DEFAULT_URL = os.getenv("CMS_PRICING_URL", default_cms_url())
 DEFAULT_PATH = os.path.join("data", "cpt_lookup.csv")
 
 


### PR DESCRIPTION
## Summary
- auto-derive CMS pricing URL based on year
- run pricing update workflow weekly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686e6c66fd4c832a980a77190e5851a9