### PR TITLE
Add filter-cases CLI command

### DIFF
--- a/docs/batch_eval.md
+++ b/docs/batch_eval.md
@@ -28,3 +28,17 @@ python cli.py batch-eval --db-sqlite cases.db --rubric rubric.json \
     --costs costs.csv --output results.csv --concurrency 4
 ```
 
+## Filtering Cases
+
+Use the `filter-cases` command to create a smaller dataset before running
+evaluations. Cases can be selected by keywords found in the summary or full
+text, or by matching metadata fields.
+
+```bash
+python cli.py filter-cases --db cases.json --keywords fever,cough \
+    --output subset.json
+
+python cli.py filter-cases --db cases.json --metadata '{"tag": "respiratory"}' \
+    --output subset.csv
+```
+


### PR DESCRIPTION
## Summary
- implement `filter-cases` subcommand in `cli.py`
- output filtered cases to JSON or CSV
- document case filtering in `docs/batch_eval.md`
- cover new command with tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xmlschema')*

------
https://chatgpt.com/codex/tasks/task_e_686e730c1b5c832a981bb872c6c5c8a6