### PR TITLE
Add translation utility with locale-aware loading

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -14,6 +14,7 @@ from .evaluation import Evaluator, async_batch_evaluate, batch_evaluate
 from .logging_config import configure_logging
 from .ingest.convert import convert_directory
 from .ingest.pipeline import run_pipeline, update_dataset
+from .ingest.translate import translate_directory
 from .cpt_lookup import lookup_cpt
 from .metrics import start_metrics_server
 from .retrieval import (
@@ -59,6 +60,7 @@ __all__ = [
     "ResultAggregator",
     "Evaluator",
     "convert_directory",
+    "translate_directory",
     "lookup_cpt",
     "run_pipeline",
     "update_dataset",

--- a/sdb/case_database.py
+++ b/sdb/case_database.py
@@ -100,17 +100,19 @@ class CaseDatabase:
         return CaseDatabase(cases)
 
     @staticmethod
-    def load_from_directory(path: str) -> "CaseDatabase":
+    def load_from_directory(path: str, locale: str | None = None) -> "CaseDatabase":
         """Load cases from a directory of text files.
 
-        Each subdirectory should contain ``summary.txt`` and ``full.txt``
-        files. The subdirectory name is used as the case ``id``.
+        Each subdirectory should contain ``summary.txt`` and ``full.txt`` files.
+        Localized variants can be named ``summary_<lang>.txt`` and
+        ``full_<lang>.txt``. The subdirectory name is used as the case ``id``.
         """
         cases = []
+        suffix = f"_{locale}" if locale else ""
         for case_id in sorted(os.listdir(path)):
             case_dir = os.path.join(path, case_id)
-            summary_file = os.path.join(case_dir, "summary.txt")
-            full_file = os.path.join(case_dir, "full.txt")
+            summary_file = os.path.join(case_dir, f"summary{suffix}.txt")
+            full_file = os.path.join(case_dir, f"full{suffix}.txt")
             if (
                 not os.path.isfile(summary_file)
                 or not os.path.isfile(full_file)

--- a/sdb/ingest/translate.py
+++ b/sdb/ingest/translate.py
@@ -1,0 +1,82 @@
+"""Utilities for translating case text into other languages."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Dict, Any
+
+from ..llm_client import OpenAIClient
+from ..config import settings
+
+
+TRANSLATE_PROMPT = (
+    "Translate the following medical text into {lang}. Only output the"
+    " translated text."
+)
+
+
+def translate_text(text: str, lang: str, client: OpenAIClient | None = None) -> str:
+    """Return ``text`` translated into ``lang`` using an LLM if available."""
+    if not text.strip():
+        return ""
+    client = client or OpenAIClient(api_key=settings.openai_api_key)
+    prompt = TRANSLATE_PROMPT.format(lang=lang)
+    reply = client.chat(
+        [{"role": "user", "content": f"{prompt}\n\n{text}"}],
+        model=os.getenv("OPENAI_MODEL", settings.openai_model),
+    )
+    return reply.strip() if reply else text
+
+
+def translate_case(
+    data: Dict[str, Any], lang: str, client: OpenAIClient | None = None
+) -> Dict[str, Any]:
+    """Return a translated copy of ``data`` for the given language code."""
+    return {
+        "id": data["id"],
+        "summary": translate_text(data.get("summary", ""), lang, client),
+        "steps": [
+            {
+                "id": step["id"],
+                "text": translate_text(step["text"], lang, client),
+            }
+            for step in data.get("steps", [])
+        ],
+    }
+
+
+def translate_directory(
+    src_dir: str,
+    lang: str,
+    dest_dir: str | None = None,
+    client: OpenAIClient | None = None,
+) -> List[str]:
+    """Translate all JSON cases in ``src_dir`` into ``lang``."""
+    dest_dir = dest_dir or src_dir
+    os.makedirs(dest_dir, exist_ok=True)
+    written: List[str] = []
+    for name in sorted(os.listdir(src_dir)):
+        if not name.endswith(".json") or name.endswith(f"_{lang}.json"):
+            continue
+        path = os.path.join(src_dir, name)
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        out_data = translate_case(data, lang, client)
+        out_name = name[:-5] + f"_{lang}.json"
+        out_path = os.path.join(dest_dir, out_name)
+        with open(out_path, "w", encoding="utf-8") as fh:
+            json.dump(out_data, fh, ensure_ascii=False, indent=2)
+        written.append(out_path)
+    return written
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Translate case files")
+    parser.add_argument("src", help="Directory with JSON case files")
+    parser.add_argument("lang", help="Target language code, e.g. 'es'")
+    parser.add_argument("--dest", help="Output directory", default=None)
+    args = parser.parse_args()
+    translate_directory(args.src, args.lang, args.dest)

--- a/tasks.yml
+++ b/tasks.yml
@@ -524,6 +524,26 @@ phases:
   epic: Phase 5
   assigned_to: null
 
+- id: 75
+  title: Provide Case Translation Utility
+  description: >
+    Add a script to translate case JSON files using an LLM and store localized
+    versions with language suffixes.
+  component: ingestion
+  area: localization
+  dependencies: []
+  priority: 3
+  status: done
+  actionable_steps:
+    - Create `sdb.ingest.translate` with helper functions.
+    - Write translated files alongside originals like `case_001_es.json`.
+    - Allow `CaseDatabase.load_from_directory` to select files by locale.
+  acceptance_criteria:
+    - "Translations can be generated and loaded by specifying a locale."
+  command: null
+  epic: Phase 5
+  assigned_to: null
+
 - id: 76
   title: Support Persona-Specific Models
   description: >

--- a/tests/test_case_database.py
+++ b/tests/test_case_database.py
@@ -42,6 +42,20 @@ def test_load_from_directory(tmp_path):
     assert db.get_case("4").full_text == "ff"
 
 
+def test_load_from_directory_locale(tmp_path):
+    case_dir = tmp_path / "5"
+    case_dir.mkdir()
+    (case_dir / "summary.txt").write_text("eng")
+    (case_dir / "full.txt").write_text("engf")
+    (case_dir / "summary_es.txt").write_text("esp")
+    (case_dir / "full_es.txt").write_text("espf")
+
+    db = CaseDatabase.load_from_directory(tmp_path, locale="es")
+    case = db.get_case("5")
+    assert case.summary == "esp"
+    assert case.full_text == "espf"
+
+
 def test_load_from_sqlite_lazy(tmp_path):
     path = tmp_path / "cases.db"
     cases = [{"id": "5", "summary": "s", "full_text": "f"}]

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,0 +1,28 @@
+import json
+from sdb.ingest.translate import translate_directory
+
+
+class DummyClient:
+    def __init__(self):
+        self.calls = []
+
+    def chat(self, messages, model):
+        self.calls.append(messages[-1]["content"])
+        return "T:" + messages[-1]["content"]
+
+
+def test_translate_directory(tmp_path):
+    src = tmp_path / "src"
+    dest = tmp_path / "dest"
+    src.mkdir()
+    data = {"id": "case_1", "summary": "sum", "steps": [{"id": 1, "text": "txt"}]}
+    (src / "case_1.json").write_text(json.dumps(data))
+
+    client = DummyClient()
+    translate_directory(str(src), "es", dest_dir=str(dest), client=client)
+
+    out_path = dest / "case_1_es.json"
+    out_data = json.loads(out_path.read_text())
+    assert out_data["summary"].startswith("T:")
+    assert out_data["steps"][0]["text"].startswith("T:")
+    assert client.calls


### PR DESCRIPTION
## Summary
- add `translate.py` for translating case text via OpenAI
- load directory cases using language suffixes
- expose `translate_directory` from package
- support locale parameter when loading cases
- test translation script and locale loading
- document translation task in roadmap

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q -r requirements.lock`
- `pip install -q xmlschema httpx_ws pytest-asyncio`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e775d83f0832abfc4e291707dcaf1