### PR TITLE
Add retrieval plugin entry points

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,6 +80,20 @@ pip install -r requirements.lock
 The `pytest` suite relies on packages such as `numpy`, `httpx`,
 `starlette`, and `pydantic`.
 
+## Retrieval Plugins
+
+Third-party retrieval backends can be integrated through Python entry points.
+Expose your index class in a small package and declare it under the
+`sdb.retrieval_plugins` group in `pyproject.toml`:
+
+```toml
+[project.entry-points."sdb.retrieval_plugins"]
+my-index = "my_package.module:MyIndex"
+```
+
+After installing the package with `pip`, the gatekeeper can load your plugin
+instead of the built-in backends.
+
 ## Data Versioning with DVC
 
 The case data and computed embeddings are tracked with [DVC](https://dvc.org/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,7 @@ include-package-data = true
 
 [project.entry-points."dx0.personas"]
 optimist = "sdb.plugins.optimist_plugin:optimistic_chain"
+
+[project.entry-points."sdb.retrieval_plugins"]
+sentence-transformer = "sdb.retrieval:SentenceTransformerIndex"
+faiss = "sdb.retrieval:FaissIndex"

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -22,6 +22,7 @@ from .retrieval import (
     FaissIndex,
     SentenceTransformerIndex,
     CrossEncoderReranker,
+    get_retrieval_plugin,
 )
 from .services import BudgetManager, BudgetStore, ResultAggregator
 from .statistics import load_scores, permutation_test
@@ -71,6 +72,7 @@ __all__ = [
     "FaissIndex",
     "SentenceTransformerIndex",
     "CrossEncoderReranker",
+    "get_retrieval_plugin",
     "load_scores",
     "permutation_test",
     "DiagnosisResult",

--- a/sdb/gatekeeper.py
+++ b/sdb/gatekeeper.py
@@ -12,7 +12,7 @@ from .protocol import ActionType
 from .config import settings
 
 from .case_database import CaseDatabase
-from .retrieval import SentenceTransformerIndex
+from .retrieval import FAISS_AVAILABLE, get_retrieval_plugin
 
 logger = structlog.get_logger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -77,9 +77,9 @@ class Gatekeeper:
                     docs.extend(
                         [p.strip() for p in text.split("\n") if p.strip()]
                     )
-            self.index = SentenceTransformerIndex(
-                docs, cross_encoder_name=cross_encoder_name
-            )
+            plugin_name = "faiss" if FAISS_AVAILABLE else "sentence-transformer"
+            index_cls = get_retrieval_plugin(plugin_name)
+            self.index = index_cls(docs, cross_encoder_name=cross_encoder_name)
 
     def load_results_from_json(self, path: str) -> None:
         """Load test result fixtures from a JSON file.

--- a/tasks.yml
+++ b/tasks.yml
@@ -525,6 +525,26 @@ phases:
   assigned_to: null
 
 - id: 75
+  title: Enable Pluggable Retrieval Indexes
+  description: >
+    Allow third-party retrieval backends to register via entry points so
+    alternative index implementations can be swapped in without modifying
+    the core code base.
+  component: retrieval
+  area: extensibility
+  dependencies: []
+  priority: 3
+  status: done
+  actionable_steps:
+    - Define `sdb.retrieval_plugins` entry point group.
+    - Refactor built-in indexes as plugins and update documentation.
+  acceptance_criteria:
+    - "Custom retrieval index packages can be discovered and used by Gatekeeper."
+  command: null
+  epic: Phase 5
+  assigned_to: null
+
+- id: 75
   title: Provide Case Translation Utility
   description: >
     Add a script to translate case JSON files using an LLM and store localized

--- a/tests/test_gatekeeper.py
+++ b/tests/test_gatekeeper.py
@@ -96,7 +96,7 @@ def test_cross_encoder_name_passed(monkeypatch):
         ):
             captured["name"] = cross_encoder_name
 
-    monkeypatch.setattr(gatekeeper, "SentenceTransformerIndex", DummyIndex)
+    monkeypatch.setattr(gatekeeper, "get_retrieval_plugin", lambda name: DummyIndex)
 
     case = Case(id="1", summary="s", full_text="t")
     db = CaseDatabase([case])

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -150,3 +150,13 @@ def test_faiss_index_query(monkeypatch):
     index = retrieval.FaissIndex(docs, model_name="dummy")
     results = index.query("cough", top_k=1)
     assert results[0][0] == "patient has cough"
+
+
+def test_get_retrieval_plugin_builtin():
+    cls = retrieval.get_retrieval_plugin("sentence-transformer")
+    assert cls is retrieval.SentenceTransformerIndex
+
+
+def test_get_retrieval_plugin_missing():
+    with pytest.raises(ValueError):
+        retrieval.get_retrieval_plugin("unknown")


### PR DESCRIPTION
## Summary
- support retrieval plugin entry points
- refactor FAISS and SentenceTransformer indexes into plugin system
- update Gatekeeper to load retrieval plugins
- document retrieval plugins in installation guide
- update tasks roadmap
- adjust tests for new plugin loader

## Testing
- `pip install -e . >/tmp/pip_install.log && tail -n 20 /tmp/pip_install.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7cdbee40832abd04aef8c7c106b4