### PR TITLE
Add async orchestrator budget test

### DIFF
--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -109,3 +109,35 @@ def test_gatekeeper_timeout_propagates():
     orch = Orchestrator(panel, TimeoutGatekeeper())
     with pytest.raises(TimeoutError):
         orch.run_turn("info")
+
+
+class AsyncStubPanel:
+    """Asynchronous stub panel returning predefined actions."""
+
+    def __init__(self, actions):
+        self.actions = actions
+        self.index = 0
+        self.last_case_info = ""
+
+    async def adeliberate(self, case_info: str) -> PanelAction:
+        self.last_case_info = case_info
+        action = self.actions[self.index]
+        self.index += 1
+        return action
+
+
+@pytest.mark.asyncio
+async def test_run_turn_async_budget_stops_session():
+    actions = [
+        PanelAction(ActionType.TEST, "cbc"),
+        PanelAction(ActionType.TEST, "bmp"),
+        PanelAction(ActionType.DIAGNOSIS, "flu"),
+    ]
+    panel = AsyncStubPanel(actions)
+    tracker = BudgetManager(DummyCostEstimator(), budget=7.0)
+    orch = Orchestrator(panel, DummyGatekeeper(), budget_manager=tracker)
+
+    await orch.run_turn_async("1")
+    await orch.run_turn_async("2")
+    assert orch.finished is True
+    assert orch.final_diagnosis is None


### PR DESCRIPTION
## Summary
- test that Orchestrator.run_turn_async stops when budget exceeded

## Testing
- `pytest tests/test_orchestrator.py::test_run_turn_async_budget_stops_session -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx_ws')*

------
https://chatgpt.com/codex/tasks/task_e_686e4f9aad0c832a85cfeb1409dac879