### PR TITLE
Add budget categories and limits

### DIFF
--- a/sdb/services/budget.py
+++ b/sdb/services/budget.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Dict, Optional
 
 from .budget_store import BudgetStore
 
@@ -10,12 +10,15 @@ from ..cost_estimator import CostEstimator
 
 @dataclass
 class BudgetManager:
-    """Track test spending and enforce an optional budget."""
+    """Track test spending and enforce optional per-category budgets."""
 
     cost_estimator: Optional[CostEstimator] = None
     budget: Optional[float] = None
+    category_limits: Dict[str, float] | None = None
     store: BudgetStore | None = None
     spent: float = 0.0
+    spent_by_category: Dict[str, float] = field(default_factory=dict)
+    test_categories: Dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.store is not None:
@@ -24,12 +27,24 @@ class BudgetManager:
     def add_test(self, test_name: str) -> None:
         """Record the cost of ``test_name`` using ``cost_estimator``."""
         amount = 0.0
+        category = "unknown"
         if self.cost_estimator:
-            amount = self.cost_estimator.estimate_cost(test_name)
+            amount, category = self.cost_estimator.estimate(test_name)
         self.spent += amount
+        self.spent_by_category[category] = (
+            self.spent_by_category.get(category, 0.0) + amount
+        )
+        self.test_categories[test_name] = category
         if self.store is not None:
             self.store.record(test_name, amount)
 
     def over_budget(self) -> bool:
-        """Return ``True`` if the budget was exceeded."""
-        return self.budget is not None and self.spent >= self.budget
+        """Return ``True`` if any spending limit was exceeded."""
+
+        if self.budget is not None and self.spent >= self.budget:
+            return True
+        if self.category_limits:
+            for cat, limit in self.category_limits.items():
+                if self.spent_by_category.get(cat, 0.0) >= limit:
+                    return True
+        return False

--- a/tests/test_cost_estimator.py
+++ b/tests/test_cost_estimator.py
@@ -7,12 +7,12 @@ from sdb import cost_estimator as ce_mod
 
 def test_lookup_and_estimate(monkeypatch):
     data = [
-        {"test_name": "cbc", "cpt_code": "100", "price": "10"},
-        {"test_name": "bmp", "cpt_code": "101", "price": "20"},
+        {"test_name": "cbc", "cpt_code": "100", "price": "10", "category": "labs"},
+        {"test_name": "bmp", "cpt_code": "101", "price": "20", "category": "imaging"},
     ]
     with tempfile.NamedTemporaryFile("w", newline="", delete=False) as f:
         writer = csv.DictWriter(
-            f, fieldnames=["test_name", "cpt_code", "price"]
+            f, fieldnames=["test_name", "cpt_code", "price", "category"]
         )
         writer.writeheader()
         writer.writerows(data)
@@ -23,8 +23,10 @@ def test_lookup_and_estimate(monkeypatch):
     monkeypatch.setattr(ce_mod, "lookup_cpt", lambda name: "101")
 
     assert ce.lookup_cost("cbc").price == 10.0
+    assert ce.lookup_cost("cbc").category == "labs"
     assert ce.lookup_cost("basic metabolic panel").cpt_code == "101"
     assert ce.estimate_cost("unknown") == 20.0
+    assert ce.estimate("unknown") == (20.0, "imaging")
     assert ce.aliases["unknown"] == "bmp"
     # Second call should use cached alias and avoid LLM lookup
     monkeypatch.setattr(

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -66,6 +66,9 @@ class DummyCostEstimator:
     def estimate_cost(self, test_name: str) -> float:
         return 5.0
 
+    def estimate(self, test_name: str) -> tuple[float, str]:
+        return 5.0, "labs"
+
 
 def test_orchestrator_budget_stops_session():
     actions = [
@@ -82,6 +85,23 @@ def test_orchestrator_budget_stops_session():
     )
 
     orch.run_turn("1")
+    orch.run_turn("2")
+    assert orch.finished is True
+    assert orch.final_diagnosis is None
+
+
+def test_category_limit_stops_session():
+    actions = [
+        PanelAction(ActionType.TEST, "cbc"),
+        PanelAction(ActionType.TEST, "bmp"),
+        PanelAction(ActionType.DIAGNOSIS, "flu"),
+    ]
+    panel = StubPanel(actions)
+    tracker = BudgetManager(DummyCostEstimator(), category_limits={"labs": 7.0})
+    orch = Orchestrator(panel, DummyGatekeeper(), budget_manager=tracker)
+
+    orch.run_turn("1")
+    assert orch.finished is False
     orch.run_turn("2")
     assert orch.finished is True
     assert orch.final_diagnosis is None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5,14 +5,19 @@ class DummyEstimator:
     def estimate_cost(self, _name: str) -> float:
         return 5.0
 
+    def estimate(self, _name: str) -> tuple[float, str]:
+        return 5.0, "labs"
+
 
 def test_budget_manager_over_budget():
     bm = BudgetManager(DummyEstimator(), budget=9.0)
     bm.add_test("cbc")
     assert bm.spent == 5.0
+    assert bm.spent_by_category["labs"] == 5.0
     assert not bm.over_budget()
     bm.add_test("bmp")
     assert bm.spent == 10.0
+    assert bm.spent_by_category["labs"] == 10.0
     assert bm.over_budget()
 
 


### PR DESCRIPTION
## Summary
- categorize costs using CostEstimator
- track per-category spending in BudgetManager
- support category budgets in Orchestrator
- test category enforcement and new estimator API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_686e9deba014832a843881fb3be74331