### PR TITLE
Add export-fhir subcommand

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -392,6 +392,40 @@ def fhir_export_main(argv: list[str]) -> None:
         print(output)
 
 
+def export_fhir_main(argv: list[str]) -> None:
+    """Convert a saved transcript to a FHIR bundle file."""
+
+    parser = argparse.ArgumentParser(description="Export a transcript to FHIR")
+    parser.add_argument("transcript", help="Path to JSON transcript file")
+    parser.add_argument(
+        "--case-id",
+        default="case_001",
+        help="Identifier for the session/case",
+    )
+    parser.add_argument(
+        "--patient-id",
+        default="example",
+        help="Patient identifier used in references",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default="fhir",
+        help="Directory for the generated bundle",
+    )
+    args = parser.parse_args(argv)
+
+    with open(args.transcript, "r", encoding="utf-8") as fh:
+        transcript = json.load(fh)
+
+    bundle = transcript_to_fhir(transcript, patient_id=args.patient_id)
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    out_path = os.path.join(args.output_dir, f"{args.case_id}.json")
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump(bundle, fh, indent=2)
+
+
 def fhir_import_main(argv: list[str]) -> None:
     """Convert a FHIR bundle or DiagnosticReport to case JSON."""
 
@@ -847,6 +881,8 @@ if __name__ == "__main__":
         fhir_export_main(sys.argv[2:])
     elif len(sys.argv) > 1 and sys.argv[1] == "fhir-import":
         fhir_import_main(sys.argv[2:])
+    elif len(sys.argv) > 1 and sys.argv[1] == "export-fhir":
+        export_fhir_main(sys.argv[2:])
     elif len(sys.argv) > 1 and sys.argv[1] == "annotate-case":
         annotate_case_main(sys.argv[2:])
     elif len(sys.argv) > 1 and sys.argv[1] == "filter-cases":

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,6 +36,12 @@ To start the demo web UI locally:
 uvicorn sdb.ui.app:app --reload
 ```
 
+Export a saved transcript to a FHIR bundle:
+
+```bash
+python cli.py export-fhir session.json --case-id case_001 --output-dir fhir
+```
+
 ## Environment Setup
 
 ### Using the OpenAI API

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -874,3 +874,29 @@ def test_filter_cases_command(tmp_path):
         rows = list(csv.DictReader(fh))
     assert len(rows) == 1
     assert rows[0]["id"] == "2"
+
+
+def test_export_fhir_command(tmp_path):
+    transcript = [["panel", "hello"], ["gatekeeper", "hi"]]
+    t_file = tmp_path / "t.json"
+    with open(t_file, "w", encoding="utf-8") as f:
+        json.dump(transcript, f)
+
+    out_dir = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        "cli.py",
+        "export-fhir",
+        str(t_file),
+        "--case-id",
+        "c1",
+        "--output-dir",
+        str(out_dir),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    out_file = out_dir / "c1.json"
+    with open(out_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["resourceType"] == "Bundle"
+    assert data["entry"][0]["resource"]["sender"]["display"] == "panel"


### PR DESCRIPTION
## Summary
- implement `export_fhir_main` and hook into CLI
- document transcript export in installation guide
- cover new command with a unit test

## Testing
- `pip install -q -r requirements.lock`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xmlschema')*

------
https://chatgpt.com/codex/tasks/task_e_686ea40c119c832aa55aa50bec412b00