### PR TITLE
Add Slurm batch evaluation helper

### DIFF
--- a/docs/slurm_batch_eval.sbatch
+++ b/docs/slurm_batch_eval.sbatch
@@ -1,0 +1,10 @@
+#!/bin/bash
+#SBATCH --job-name=batch_eval
+#SBATCH --array=1-10
+#SBATCH --output=logs/batch_eval_%a.out
+
+# Example Slurm submission script
+python scripts/slurm_batch_eval.py \
+  --start 1 --end 10 \
+  --concurrency 4 \
+  --output results.csv

--- a/scripts/slurm_batch_eval.py
+++ b/scripts/slurm_batch_eval.py
@@ -1,0 +1,52 @@
+"""Submit batch_evaluate jobs as a Slurm array."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+from pathlib import Path
+
+from sdb.evaluation import batch_evaluate
+
+
+def run_case(case_id: str) -> dict[str, str]:
+    """Example case evaluation function."""
+    return {"id": case_id, "score": "0"}
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run ``batch_evaluate`` for a Slurm task."""
+    parser = argparse.ArgumentParser(description="Run batch evaluations")
+    parser.add_argument("--start", type=int, required=True, help="First case id")
+    parser.add_argument("--end", type=int, required=True, help="Last case id")
+    parser.add_argument(
+        "--concurrency", type=int, default=2, help="Concurrent sessions"
+    )
+    parser.add_argument("--output", required=True, help="CSV result file")
+    args = parser.parse_args(argv)
+
+    case_ids = [str(i) for i in range(args.start, args.end + 1)]
+    task_id = os.environ.get("SLURM_ARRAY_TASK_ID")
+    if task_id:
+        idx = int(task_id) - 1
+        if 0 <= idx < len(case_ids):
+            case_ids = [case_ids[idx]]
+
+    results = batch_evaluate(case_ids, run_case, concurrency=args.concurrency)
+
+    out_path = Path(args.output)
+    if task_id:
+        out_path = out_path.with_name(f"{out_path.stem}_{task_id}{out_path.suffix}")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fieldnames = sorted(results[0].keys()) if results else []
+    with open(out_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        if fieldnames:
+            writer.writeheader()
+            writer.writerows(results)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tasks.yml
+++ b/tasks.yml
@@ -1244,3 +1244,21 @@ phases:
   epic: Phase 5
   assigned_to: null
 
+
+- id: 75
+  title: Slurm Batch Evaluation Helper
+  description: |
+    Provide a script for submitting `batch_evaluate` jobs as a Slurm array to ease large scale experiments.
+  component: scripts
+  area: performance
+  dependencies: []
+  priority: 3
+  status: done
+  actionable_steps:
+    - Implement `scripts/slurm_batch_eval.py`.
+    - Document usage with an example submission file.
+  acceptance_criteria:
+    - "Users can launch evaluations on HPC clusters using Slurm arrays."
+  command: null
+  epic: Phase 5
+  assigned_to: null


### PR DESCRIPTION
## Summary
- add a script for submitting `batch_evaluate` jobs to a Slurm array
- document usage with a small example sbatch file
- track the new helper in the project roadmap

## Testing
- `pytest tests/test_evaluation.py::test_async_batch_evaluate -q`

------
https://chatgpt.com/codex/tasks/task_e_686ea6ec1b14832a83c2bb75ccf51e58