### PR TITLE
Add FHIR de-identification script

### DIFF
--- a/scripts/deidentify_fhir.py
+++ b/scripts/deidentify_fhir.py
@@ -1,0 +1,86 @@
+"""Remove personal identifiers from FHIR Bundles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+# Keys matching this regex will be removed unless whitelisted.
+PHI_KEY_PATTERN = re.compile(
+    r"name|telecom|phone|email|address|birthdate|given|family|city|state|postalcode",
+    re.IGNORECASE,
+)
+
+# Patterns within string values to redact.
+PHI_VALUE_PATTERNS: Iterable[re.Pattern[str]] = [
+    re.compile(r"\b\d{3}-\d{3}-\d{4}\b"),
+    re.compile(r"\b[\w.-]+@[\w.-]+\.[A-Za-z]{2,}\b"),
+]
+
+# Allowed fields which should not be stripped even if they match the PHI regex.
+WHITELIST = {
+    "resourceType",
+    "id",
+    "status",
+    "code",
+    "text",
+    "valueString",
+    "valueCodeableConcept",
+    "valueQuantity",
+    "result",
+    "contained",
+    "entry",
+    "conclusion",
+}
+
+
+def _clean_value(value: Any) -> Any:
+    """Return ``value`` with PHI patterns redacted."""
+    if isinstance(value, str):
+        for pat in PHI_VALUE_PATTERNS:
+            value = pat.sub("[REDACTED]", value)
+    return value
+
+
+def strip_identifiers(data: Any, whitelist: Iterable[str] | None = None) -> Any:
+    """Return ``data`` with personal identifiers removed."""
+    if whitelist is None:
+        whitelist = WHITELIST
+    if isinstance(data, dict):
+        cleaned = {}
+        for key, val in data.items():
+            if key not in whitelist and PHI_KEY_PATTERN.search(key):
+                continue
+            cleaned[key] = strip_identifiers(val, whitelist)
+        return cleaned
+    if isinstance(data, list):
+        return [strip_identifiers(v, whitelist) for v in data]
+    return _clean_value(data)
+
+
+def main(args: list[str] | None = None) -> None:
+    """CLI entry point for FHIR de-identification."""
+    parser = argparse.ArgumentParser(description="Remove PHI from a FHIR Bundle")
+    parser.add_argument("input", help="Path to FHIR Bundle JSON")
+    parser.add_argument(
+        "output",
+        nargs="?",
+        help="Destination path (writes to stdout if omitted)",
+    )
+    parsed = parser.parse_args(args)
+
+    data = json.loads(Path(parsed.input).read_text(encoding="utf-8"))
+    cleaned = strip_identifiers(data)
+    text = json.dumps(cleaned, indent=2)
+
+    if parsed.output:
+        Path(parsed.output).write_text(text, encoding="utf-8")
+    else:
+        print(text)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/sdb/cost_estimator.py
+++ b/sdb/cost_estimator.py
@@ -78,7 +78,12 @@ class CostEstimator:
                     name = row["test_name"].strip().lower()
                     cpt = row["cpt_code"].strip()
                     price = float(row["price"])
-                    category = row.get("category", "unknown").strip().lower() or "unknown"
+                    category = (
+                        row.get("category", "unknown")
+                        .strip()
+                        .lower()
+                        or "unknown"
+                    )
                 except Exception:
                     continue
                 if name and cpt:

--- a/tests/test_fhir_import.py
+++ b/tests/test_fhir_import.py
@@ -1,4 +1,5 @@
 from sdb.fhir_import import diagnostic_report_to_case, bundle_to_case
+from scripts import deidentify_fhir as deid
 
 
 def test_diagnostic_report_to_case():
@@ -62,3 +63,34 @@ def test_bundle_to_case():
     case = bundle_to_case(bundle, case_id="case")
     assert len(case["steps"]) == 2
     assert case["steps"][0]["text"] == "foo"
+
+
+def test_deidentify_removes_phi():
+    bundle = {
+        "resourceType": "Bundle",
+        "entry": [
+            {
+                "resource": {
+                    "resourceType": "Patient",
+                    "id": "p1",
+                    "name": [{"family": "Smith"}],
+                    "telecom": [{"value": "555-111-2222"}],
+                    "address": [{"city": "Boston"}],
+                }
+            },
+            {
+                "resource": {
+                    "resourceType": "Observation",
+                    "id": "obs",
+                    "valueString": "Call 555-111-2222 or email a@b.com",
+                }
+            },
+        ],
+    }
+    cleaned = deid.strip_identifiers(bundle)
+    patient = cleaned["entry"][0]["resource"]
+    assert "name" not in patient
+    assert "telecom" not in patient
+    assert "address" not in patient
+    obs = cleaned["entry"][1]["resource"]
+    assert obs["valueString"] == "Call [REDACTED] or email [REDACTED]"


### PR DESCRIPTION
## Summary
- create `deidentify_fhir.py` to remove PHI from FHIR bundles
- test de-identification in `test_fhir_import.py`
- fix flake8 issue in `cost_estimator.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ef35c01e0832a95e5eedb95ff1a62