### PR TITLE
Add retrieval plugin loader with config support

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -232,6 +232,11 @@ def batch_eval_main(argv: list[str]) -> None:
         default=None,
         help="Cross-encoder model name for semantic retrieval",
     )
+    parser.add_argument(
+        "--retrieval-backend",
+        default=None,
+        help="Retrieval plugin name to use when semantic retrieval is enabled",
+    )
     parser.add_argument("--verbose", action="store_true")
     parser.add_argument("--quiet", action="store_true")
     args = parser.parse_args(argv)
@@ -239,6 +244,8 @@ def batch_eval_main(argv: list[str]) -> None:
     if args.db is None and args.db_sqlite is None:
         args.db = cfg.case_db
         args.db_sqlite = cfg.case_db_sqlite
+    if args.retrieval_backend is None:
+        args.retrieval_backend = cfg.retrieval_backend
 
     vote_weights = _load_weights_file(args.weights_file)
     if vote_weights is None:
@@ -282,6 +289,7 @@ def batch_eval_main(argv: list[str]) -> None:
             case_id,
             use_semantic_retrieval=args.semantic,
             cross_encoder_name=args.cross_encoder_model,
+            retrieval_backend=args.retrieval_backend,
         )
         if args.panel_engine == "rule":
             engine = RuleEngine()
@@ -796,6 +804,7 @@ def main() -> None:
         args.case,
         use_semantic_retrieval=args.semantic,
         cross_encoder_name=args.cross_encoder_model,
+        retrieval_backend=args.retrieval_backend,
     )
     gatekeeper.register_test_result("complete blood count", "normal")
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -98,7 +98,8 @@ my-index = "my_package.module:MyIndex"
 ```
 
 After installing the package with `pip`, the gatekeeper can load your plugin
-instead of the built-in backends.
+instead of the built-in backends. Set `retrieval_backend` in `settings.yaml`
+or the `SDB_RETRIEVAL_BACKEND` environment variable to select the plugin.
 
 ## Data Versioning with DVC
 

--- a/docs/retrieval_plugins.md
+++ b/docs/retrieval_plugins.md
@@ -1,0 +1,34 @@
+# Retrieval Plugins
+
+SDB uses a retrieval index to surface relevant text passages from the case database. Third-party backends can extend this system via Python entry points.
+
+## Writing a Plugin
+
+1. Implement a class providing a `query(text, top_k=1)` method:
+
+```python
+from typing import List, Tuple
+from sdb.retrieval import BaseRetrievalIndex
+
+class MyIndex(BaseRetrievalIndex):
+    def __init__(self, documents: List[str]):
+        self.documents = documents
+
+    def query(self, text: str, top_k: int = 1) -> List[Tuple[str, float]]:
+        ...  # return a ranked list of passages
+```
+
+2. Declare the entry point in your `pyproject.toml`:
+
+```toml
+[project.entry-points."sdb.retrieval_plugins"]
+my-index = "my_plugin:MyIndex"
+```
+
+3. Install the package so `importlib.metadata` can discover the entry point:
+
+```bash
+pip install -e path/to/my_plugin
+```
+
+Set `retrieval_backend` in `settings.yaml` (or the `SDB_RETRIEVAL_BACKEND` environment variable) to `my-index` and enable semantic retrieval to use your custom backend.

--- a/sdb/config.py
+++ b/sdb/config.py
@@ -15,6 +15,7 @@ class Settings(BaseModel):
     metrics_port: int = 8000
     semantic_retrieval: bool = False
     cross_encoder_model: Optional[str] = None
+    retrieval_backend: Optional[str] = None
     case_db: Optional[str] = None
     case_db_sqlite: Optional[str] = None
     parallel_personas: bool = False
@@ -65,6 +66,8 @@ def load_settings(path: str | None = None) -> Settings:
         data["case_db_sqlite"] = env("SDB_CASE_DB_SQLITE")
     if "parallel_personas" not in data and env("SDB_PARALLEL_PERSONAS"):
         data["parallel_personas"] = env("SDB_PARALLEL_PERSONAS").lower() == "true"
+    if "retrieval_backend" not in data and env("SDB_RETRIEVAL_BACKEND"):
+        data["retrieval_backend"] = env("SDB_RETRIEVAL_BACKEND")
     if "tracing" not in data and env("SDB_TRACING_ENABLED"):
         data["tracing"] = env("SDB_TRACING_ENABLED").lower() == "true"
     if "tracing_host" not in data and env("SDB_TRACING_HOST"):

--- a/sdb/retrieval.py
+++ b/sdb/retrieval.py
@@ -2,6 +2,8 @@ import re
 from typing import Dict, List, Tuple, Optional, Type, Protocol
 from importlib import metadata
 
+from .config import settings
+
 try:  # pragma: no cover - trivial import handling
     import numpy as np
 
@@ -294,3 +296,19 @@ def get_retrieval_plugin(name: str) -> Type[BaseRetrievalIndex]:
             cls = ep.load()
             return cls
     raise ValueError(f"Retrieval plugin '{name}' not found")
+
+
+def load_retrieval_index(
+    documents: List[str],
+    *,
+    plugin_name: Optional[str] = None,
+    **kwargs: object,
+) -> BaseRetrievalIndex:
+    """Instantiate the retrieval index specified by configuration."""
+
+    if plugin_name is None:
+        plugin_name = settings.retrieval_backend
+    if plugin_name is None:
+        plugin_name = "faiss" if FAISS_AVAILABLE else "sentence-transformer"
+    index_cls = get_retrieval_plugin(plugin_name)
+    return index_cls(documents, **kwargs)

--- a/tests/test_gatekeeper.py
+++ b/tests/test_gatekeeper.py
@@ -96,7 +96,7 @@ def test_cross_encoder_name_passed(monkeypatch):
         ):
             captured["name"] = cross_encoder_name
 
-    monkeypatch.setattr(gatekeeper, "get_retrieval_plugin", lambda name: DummyIndex)
+    monkeypatch.setattr(gatekeeper, "load_retrieval_index", lambda docs, **k: DummyIndex(docs, **k))
 
     case = Case(id="1", summary="s", full_text="t")
     db = CaseDatabase([case])


### PR DESCRIPTION
## Summary
- introduce `Settings.retrieval_backend`
- load retrieval backend via new `load_retrieval_index`
- allow Gatekeeper and CLI to specify backend
- document retrieval plugin development

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'starlette')*

------
https://chatgpt.com/codex/tasks/task_e_686ef7aafbe8832aa65ab6a813179c0d