### PR TITLE
Add persistent budget tracking for UI sessions

### DIFF
--- a/sdb/ui/session_db.py
+++ b/sdb/ui/session_db.py
@@ -1,10 +1,10 @@
 import sqlite3
 import time
-from typing import Optional
+from typing import Optional, Tuple
 
 
 class SessionDB:
-    """Store session tokens in a SQLite database."""
+    """Store session tokens and budget info in a SQLite database."""
 
     def __init__(self, path: str = "sessions.db", ttl: int = 3600) -> None:
         self.path = path
@@ -24,6 +24,14 @@ class SessionDB:
                     "issue_time REAL NOT NULL)"
                 )
             )
+            cur = conn.execute("PRAGMA table_info(sessions)")
+            cols = [row[1] for row in cur.fetchall()]
+            if "budget_limit" not in cols:
+                conn.execute("ALTER TABLE sessions ADD COLUMN budget_limit REAL")
+            if "amount_spent" not in cols:
+                conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN amount_spent REAL DEFAULT 0"
+                )
             conn.commit()
 
     def add(
@@ -31,15 +39,21 @@ class SessionDB:
         token: str,
         username: str,
         issue_time: Optional[float] = None,
+        *,
+        budget_limit: Optional[float] = None,
+        amount_spent: float = 0.0,
     ) -> None:
+        """Insert a session record."""
+
         ts = issue_time if issue_time is not None else time.time()
         with self._connect() as conn:
             conn.execute(
                 (
                     "INSERT OR REPLACE INTO sessions "
-                    "(token, username, issue_time) VALUES (?, ?, ?)"
+                    "(token, username, issue_time, budget_limit, amount_spent) "
+                    "VALUES (?, ?, ?, ?, ?)"
                 ),
-                (token, username, ts),
+                (token, username, ts, budget_limit, amount_spent),
             )
             conn.commit()
 
@@ -61,6 +75,29 @@ class SessionDB:
             self.remove(token)
             return None
         return username
+
+    def get_budget(self, token: str) -> Tuple[Optional[float], float]:
+        """Return budget limit and amount spent for ``token``."""
+
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT budget_limit, amount_spent FROM sessions WHERE token=?",
+                (token,),
+            )
+            row = cur.fetchone()
+        if not row:
+            return None, 0.0
+        return row[0], row[1] if row[1] is not None else 0.0
+
+    def update_spent(self, token: str, spent: float) -> None:
+        """Persist updated ``spent`` amount for ``token``."""
+
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE sessions SET amount_spent=? WHERE token=?",
+                (spent, token),
+            )
+            conn.commit()
 
     def cleanup(self) -> None:
         cutoff = time.time() - self.ttl


### PR DESCRIPTION
## Summary
- extend `SessionDB` with `budget_limit` and `amount_spent`
- make `BudgetManager` persist spending via `SessionDB`
- initialize sessions with a default budget in `app.py`
- update websocket creation to read prior budget data
- test that budget state survives server restarts

## Testing
- `pytest -q tests/test_ui.py::test_budget_persistence` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*
- `pytest -q` *(fails to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f35791e58832a8f71f29f5bf929e1