### PR TITLE
Add budget limit argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ docker build -t clinical-ai-suite .
 python -m dx0.cli \
   --mode budgeted \
   --case-file data/sdbench/cases/case_001.json \
-  --budget 1000 \
+  --budget-limit 1000 \
   --output results/dx0_case_001.json
 ```
 Budget enforcement is handled by the ``BudgetManager`` service created by the CLI.
+Set the limit with ``--budget-limit``.
 Add `--cache` to reuse previous LLM responses and reduce API calls:
 
 ```bash

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -479,6 +479,63 @@ def test_cli_persona_models(monkeypatch, tmp_path):
     assert captured["models"] == {"hypothesis_system": "gpt-4"}
 
 
+def test_cli_budget_limit(monkeypatch, tmp_path):
+    cases = [{"id": "1", "summary": "s", "full_text": "t"}]
+    case_file = tmp_path / "cases.json"
+    with open(case_file, "w", encoding="utf-8") as f:
+        json.dump(cases, f)
+
+    rubric_file = tmp_path / "r.json"
+    with open(rubric_file, "w", encoding="utf-8") as f:
+        json.dump({}, f)
+
+    cost_file = tmp_path / "c.csv"
+    with open(cost_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["test_name", "cpt_code", "price"],
+        )
+        writer.writeheader()
+        writer.writerow({"test_name": "x", "cpt_code": "1", "price": "1"})
+
+    captured: dict[str, float | None] = {}
+
+    class DummyBudgetManager:
+        def __init__(self, *args, **kwargs):
+            captured["limit"] = kwargs.get("budget")
+
+    class DummyOrchestrator:
+        def __init__(self, *args, **kwargs):
+            self.finished = True
+            self.total_time = 0.0
+            self.final_diagnosis = ""
+            self.ordered_tests = []
+
+        def run_turn(self, *_args, **_kwargs):
+            return ""
+
+    monkeypatch.setattr(cli, "BudgetManager", DummyBudgetManager)
+    monkeypatch.setattr(cli, "Orchestrator", DummyOrchestrator)
+    monkeypatch.setattr(cli, "start_metrics_server", lambda *_: None)
+
+    argv = [
+        "cli.py",
+        "--db",
+        str(case_file),
+        "--case",
+        "1",
+        "--rubric",
+        str(rubric_file),
+        "--costs",
+        str(cost_file),
+        "--budget-limit",
+        "5",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    cli.main()
+    assert captured["limit"] == 5.0
+
+
 def test_batch_eval_ollama_base_url(monkeypatch, tmp_path):
     cases = [{"id": "1", "summary": "s", "full_text": "t"}]
     case_file = tmp_path / "cases.json"


### PR DESCRIPTION
## Summary
- add `--budget-limit` argument for main and batch CLI run modes
- propagate this limit to the `BudgetManager`
- document budget limit usage in README
- test flag wiring via new unit test

## Testing
- `pytest tests/test_cli.py::test_cli_budget_limit -q`
- `pytest -q` *(fails: fastapi/httpx_ws and other deps missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f38a8945c832a8fd63ccb17c34efc