### PR TITLE
Add Prometheus gauges for budget usage

### DIFF
--- a/scripts/start_metrics_server.py
+++ b/scripts/start_metrics_server.py
@@ -1,0 +1,20 @@
+import argparse
+import time
+from sdb.metrics import start_metrics_server
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Start Prometheus metrics server")
+    parser.add_argument("--port", type=int, default=None, help="Port to bind")
+    args = parser.parse_args()
+    start_metrics_server(args.port)
+    print("Metrics server running. Press Ctrl-C to stop.")
+    try:
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/sdb/metrics.py
+++ b/sdb/metrics.py
@@ -1,7 +1,7 @@
 """Prometheus metrics helpers for MAI-DxO."""
 
 import os
-from prometheus_client import Counter, Histogram, start_http_server
+from prometheus_client import Counter, Gauge, Histogram, start_http_server
 from .config import settings
 
 ORCHESTRATOR_TURNS = Counter(
@@ -20,7 +20,8 @@ LLM_LATENCY = Histogram(
 
 # Time spent processing each orchestrator turn.
 ORCHESTRATOR_LATENCY = Histogram(
-    "orchestrator_turn_seconds", "Time spent in each orchestrator turn.",
+    "orchestrator_turn_seconds",
+    "Time spent in each orchestrator turn.",
 )
 
 LLM_TOKENS = Counter(
@@ -48,6 +49,16 @@ CPT_CACHE_HITS = Counter(
 # Count of CPT lookups that required an LLM call.
 CPT_LLM_LOOKUPS = Counter(
     "cpt_llm_lookups_total", "Number of CPT lookups resolved via LLM."
+)
+
+# Budget tracking metrics
+BUDGET_SPENT = Gauge(
+    "budget_spent",
+    "Total budget spent in dollars.",
+)
+BUDGET_REMAINING = Gauge(
+    "budget_remaining",
+    "Remaining budget in dollars.",
 )
 
 

--- a/sdb/services/budget.py
+++ b/sdb/services/budget.py
@@ -7,6 +7,7 @@ from .budget_store import BudgetStore
 from ..ui.session_db import SessionDB
 
 from ..cost_estimator import CostEstimator
+from ..metrics import BUDGET_REMAINING, BUDGET_SPENT
 
 
 @dataclass
@@ -43,6 +44,10 @@ class BudgetManager:
             self.spent_by_category.get(category, 0.0) + amount
         )
         self.test_categories[test_name] = category
+        BUDGET_SPENT.inc(amount)
+        if self.budget is not None:
+            remaining = max(self.budget - self.spent, 0.0)
+            BUDGET_REMAINING.set(remaining)
         if self.store is not None:
             self.store.record(test_name, amount)
         if self.session_db is not None and self.session_token is not None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,4 +1,5 @@
 from sdb.services import BudgetManager, ResultAggregator
+from sdb.metrics import BUDGET_REMAINING, BUDGET_SPENT
 
 
 class DummyEstimator:
@@ -30,3 +31,12 @@ def test_result_aggregator_records():
     agg.record_diagnosis("flu")
     assert agg.final_diagnosis == "flu"
     assert agg.finished
+
+
+def test_budget_metrics_update():
+    BUDGET_SPENT.set(0)
+    BUDGET_REMAINING.set(0)
+    bm = BudgetManager(DummyEstimator(), budget=10.0)
+    bm.add_test("cbc")
+    assert BUDGET_SPENT._value.get() == 5.0
+    assert BUDGET_REMAINING._value.get() == 5.0


### PR DESCRIPTION
## Summary
- track budget spent and remaining with new gauges
- update `BudgetManager.add_test` to record these metrics
- provide a helper script to launch the metrics server
- test that gauges increment when a test is added

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xmlschema')*
- `PYTHONPATH=. python scripts/start_metrics_server.py --port 8001` and queried `/metrics`

------
https://chatgpt.com/codex/tasks/task_e_686f4059bf80832a8cd908bc7475910c