### PR TITLE
Improve pricing ingestion checks

### DIFF
--- a/tests/test_cost_estimator.py
+++ b/tests/test_cost_estimator.py
@@ -86,12 +86,13 @@ def test_coverage_check(tmp_path):
         writer.writeheader()
         writer.writerows(cms_rows)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         CostEstimator.load_from_csv(
             str(cost_path),
             cms_pricing_path=str(cms_path),
-            coverage_threshold=0.98,
+            coverage_threshold=1.0,
         )
+    assert "101" in str(exc.value)
 
 
 def test_lookup_cost_missing():

--- a/tests/test_gatekeeper.py
+++ b/tests/test_gatekeeper.py
@@ -93,10 +93,15 @@ def test_cross_encoder_name_passed(monkeypatch):
             *,
             cross_encoder_name=None,
             rerank_k=5,
+            plugin_name=None,
         ):
             captured["name"] = cross_encoder_name
 
-    monkeypatch.setattr(gatekeeper, "load_retrieval_index", lambda docs, **k: DummyIndex(docs, **k))
+    monkeypatch.setattr(
+        gatekeeper,
+        "load_retrieval_index",
+        lambda docs, **k: DummyIndex(docs, **k),
+    )
 
     case = Case(id="1", summary="s", full_text="t")
     db = CaseDatabase([case])

--- a/tests/test_update_cms_pricing.py
+++ b/tests/test_update_cms_pricing.py
@@ -1,5 +1,6 @@
 import csv
 from types import SimpleNamespace
+import pytest
 
 import scripts.update_cms_pricing as ucp
 
@@ -34,3 +35,33 @@ def test_refresh_pricing(tmp_path, monkeypatch):
         rows = list(csv.DictReader(f))
 
     assert rows[0]["price"] == "11.0"
+
+
+def test_refresh_pricing_low_coverage(tmp_path, monkeypatch):
+    cms_csv = "code,rate\n85027,11.0\n"
+
+    def fake_get(url, timeout=60):
+        return SimpleNamespace(
+            content=cms_csv.encode(),
+            text=cms_csv,
+            status_code=200,
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr(ucp, "requests", SimpleNamespace(get=fake_get))
+
+    path = tmp_path / "cpt.csv"
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["test_name", "cpt_code", "price"],
+        )
+        writer.writeheader()
+        writer.writerow({"test_name": "cbc", "cpt_code": "99999", "price": "9"})
+
+    with pytest.raises(ValueError):
+        ucp.refresh_pricing(
+            str(path),
+            "https://example.com/data.csv",
+            coverage_threshold=1.0,
+        )


### PR DESCRIPTION
## Summary
- log unmatched codes in CostEstimator
- validate CPT coverage during pricing updates
- expose coverage threshold option in pricing script
- test failure message when pricing coverage is low
- fix gatekeeper test for flake8

## Testing
- `pip install -e .`
- `pip install xmlschema httpx_ws pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f433ae320832aaaa9a9b10d9a7c17