### PR TITLE
Add async gatekeeper methods and update orchestrator

### DIFF
--- a/sdb/gatekeeper.py
+++ b/sdb/gatekeeper.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict
+import asyncio
 import json
 import structlog
 import os
@@ -117,9 +118,19 @@ class Gatekeeper:
         for name, result in data.items():
             self.register_test_result(name, str(result))
 
+    async def aload_results_from_json(self, path: str) -> None:
+        """Asynchronous version of :meth:`load_results_from_json`."""
+
+        await asyncio.to_thread(self.load_results_from_json, path)
+
     def register_test_result(self, test_name: str, result: str):
         """Add known test result for the current case."""
         self.known_tests[test_name.lower()] = result
+
+    async def aregister_test_result(self, test_name: str, result: str) -> None:
+        """Asynchronous version of :meth:`register_test_result`."""
+
+        await asyncio.to_thread(self.register_test_result, test_name, result)
 
     def answer_question(self, query: str) -> QueryResult:
         """Return relevant snippet from case or synthetic result."""
@@ -213,3 +224,8 @@ class Gatekeeper:
         result = QueryResult("Unknown action", synthetic=True)
         logger.info("gatekeeper_result", synthetic=True)
         return result
+
+    async def aanswer_question(self, query: str) -> QueryResult:
+        """Asynchronous version of :meth:`answer_question`."""
+
+        return await asyncio.to_thread(self.answer_question, query)

--- a/sdb/orchestrator.py
+++ b/sdb/orchestrator.py
@@ -169,7 +169,10 @@ class Orchestrator:
                     action = PanelAction(ActionType.QUESTION, action.content)
 
                 xml = build_action(action.action_type, action.content)
-                result = await asyncio.to_thread(self.gatekeeper.answer_question, xml)
+                if hasattr(self.gatekeeper, "aanswer_question"):
+                    result = await self.gatekeeper.aanswer_question(xml)  # type: ignore[attr-defined]
+                else:
+                    result = await asyncio.to_thread(self.gatekeeper.answer_question, xml)
                 logger.info(
                     "gatekeeper_response",
                     synthetic=result.synthetic,

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -101,6 +101,9 @@ class AGatekeeper:
     def answer_question(self, xml: str):
         return DummyResult("ack")
 
+    async def aanswer_question(self, xml: str):
+        return self.answer_question(xml)
+
 
 async def async_run_case(cid: str) -> dict[str, str]:
     panel = VirtualPanel(decision_engine=LLMEngine(client=DummyAsyncClient()))

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -19,6 +19,9 @@ class DummyGatekeeper:
     def answer_question(self, xml: str) -> DummyResult:
         return DummyResult("ack")
 
+    async def aanswer_question(self, xml: str) -> DummyResult:
+        return self.answer_question(xml)
+
 
 def test_run_turn_passes_case_info():
     panel = VirtualPanel()
@@ -130,6 +133,9 @@ class TimeoutPanel:
 
 class TimeoutGatekeeper:
     def answer_question(self, xml: str) -> DummyResult:
+        raise TimeoutError("gatekeeper timeout")
+
+    async def aanswer_question(self, xml: str) -> DummyResult:
         raise TimeoutError("gatekeeper timeout")
 
 


### PR DESCRIPTION
## Summary
- support async operation in gatekeeper with `aanswer_question`
- wrap loading/registering helpers with async variants
- call async gatekeeper from `run_turn_async`
- update tests to exercise async path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'starlette')*

------
https://chatgpt.com/codex/tasks/task_e_686f4dbbc130832a8e194d754fcadc68