### PR TITLE
Add flake8 lint job

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 88

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           ./scripts/install_dev_deps.sh
       - name: Run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files
+      - name: Run flake8
+        run: flake8 .
       - name: Run tests
         run: pytest -q
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 /.dvc/cache
 /.dvc/tmp
 dvc_storage/
+*.egg-info/
+sessions.db

--- a/cli.py
+++ b/cli.py
@@ -886,7 +886,7 @@ def main() -> None:
     max_turns = 1 if args.mode == "instant" else 10
     while not orchestrator.finished and turn < max_turns:
         response = orchestrator.run_turn("")
-        print(f"Turn {turn+1}: {response}")
+        print(f"Turn {turn + 1}: {response}")
         turn += 1
 
     diag_result = DiagnosisResult(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+exclude = .git,__pycache__,build,dist
+ignore = E203,W503,E226,E501


### PR DESCRIPTION
## Summary
- enforce linting with flake8 in CI
- configure flake8 options in `setup.cfg`
- ignore build artefacts in `.gitignore`
- fix minor lint in `cli.py`

## Testing
- `python -m flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f54c97e34832a95a054116cbf65cf