### PR TITLE
Document budget manager and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ relies on a ``CostEstimator`` to translate test names into prices and can be
 passed to :class:`Orchestrator` or created automatically when the CLI runs in
 ``budgeted`` mode.
 
+```python
+from sdb import BudgetManager, CostEstimator, Orchestrator
+
+costs = CostEstimator.load_from_csv("data/sdbench/costs.csv")
+bm = BudgetManager(costs, budget=500)
+orc = Orchestrator(panel, gatekeeper, budget_manager=bm)
+```
+
 ---
 
 ## SDBench: Sequential Diagnosis Benchmark

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,7 @@ Run the CLI on a single case in budgeted mode:
 python -m dx0.cli \
   --mode budgeted \
   --case-file data/sdbench/cases/case_001.json \
-  --budget 1000 \
+  --budget-limit 1000 \
   --output results/case_001.json
 ```
 
@@ -126,6 +126,13 @@ pip install -r requirements.lock
 Start the server and open `http://localhost:8000`:
 
 ```bash
+uvicorn sdb.ui.app:app --reload
+```
+
+Set `UI_BUDGET_LIMIT` to change the default spending cap for new sessions:
+
+```bash
+export UI_BUDGET_LIMIT=750
 uvicorn sdb.ui.app:app --reload
 ```
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## v0.4.0
+
+* Introduced a `BudgetManager` service to track test spending and enforce
+  per-session limits.
+* Added the `--budget-limit` CLI flag and `UI_BUDGET_LIMIT` environment
+  variable for configuring default budgets.
+
 ## v0.3.0
 
 * Added a `WeightedVoter` that combines panel diagnoses using confidence


### PR DESCRIPTION
## Summary
- add release note for BudgetManager service
- show budgeting example in README
- mention UI_BUDGET_LIMIT and update CLI example in installation docs

## Testing
- `pip install -q pytest-asyncio anyio xmlschema httpx_ws`
- `pip install -e . -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f61ec604c832abc00ac8c9bb2ad4a