### PR TITLE
Update docs for BudgetManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ This repository contains two integrated projects for advancing sequential clinic
 ### BudgetManager
 
 The ``BudgetManager`` service keeps a running total of ordered test costs and
-optionally stops a session once spending exceeds a configurable limit.  It
-relies on a ``CostEstimator`` to translate test names into prices and can be
-passed to :class:`Orchestrator` or created automatically when the CLI runs in
+optionally stops a session once spending exceeds a configurable limit. It replaces the earlier budget tracker and relies on a ``CostEstimator`` to
+translate test names into prices. The manager can be passed to
+:class:`Orchestrator` or created automatically when the CLI runs in
 ``budgeted`` mode.
 
 ```python

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,8 @@ The React demo arranges four panels in a two-column grid:
 * **Case Summary** – shows the summary text returned by `/case`.
 * **Ordered Tests** – lists completed labs or imaging studies.
 * **Chat Panel** – spans both columns and displays the running conversation and
-  cost tracker.
+  live cost summary from the `BudgetManager` service (replacing the former
+  budget tracker).
 * **Diagnostic Flow** – captures a step-by-step log of the debate.
 
 Together these panels provide an overview of the ordered tests and reasoning

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,7 +3,7 @@
 ## v0.4.0
 
 * Introduced a `BudgetManager` service to track test spending and enforce
-  per-session limits.
+  per-session limits. This replaces the former budget tracker component.
 * Added the `--budget-limit` CLI flag and `UI_BUDGET_LIMIT` environment
   variable for configuring default budgets.
 


### PR DESCRIPTION
## Summary
- document new BudgetManager service replacing previous tracker
- note replacement in release notes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'starlette')*

------
https://chatgpt.com/codex/tasks/task_e_686f7d1767a0832aaadbf103e17ddf57