### PR TITLE
Update budget manager docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ This repository contains two integrated projects for advancing sequential clinic
   * *Stewardship*: Monitors and enforces cost budgets.
   * *Checklist*: Ensures reasoning completeness before final verdict.
 * **Gatekeeper Interface**: Information oracle that reveals only requested findings, synthesizes plausible results for unqueried tests.
-* **Cost Estimator**: Maps tests to CPT codes and CMS prices, maintaining cumulative cost tracking.
+* **Cost Estimator**: Maps tests to CPT codes and CMS prices.
+* **BudgetManager**: Tracks cumulative spending with the estimator and halts a session when a limit is reached.
 * **Evaluation Modes**: Modes for exploring different cost-accuracy scenarios: Instant Answer, Question-Only, Budgeted, Unconstrained Budget, and Ensemble.
 
 ### BudgetManager

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,8 @@ The React demo arranges four panels in a two-column grid:
 * **Case Summary** – shows the summary text returned by `/case`.
 * **Ordered Tests** – lists completed labs or imaging studies.
 * **Chat Panel** – spans both columns and displays the running conversation and
-  live cost summary from the `BudgetManager` service (replacing the former
-  budget tracker).
+  live cost summary from :class:`sdb.services.BudgetManager` (which
+  replaced the previous `BudgetTracker`).
 * **Diagnostic Flow** – captures a step-by-step log of the debate.
 
 Together these panels provide an overview of the ordered tests and reasoning

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,6 +30,9 @@ python -m dx0.cli \
   --output results/case_001.json
 ```
 
+The CLI instantiates :class:`sdb.services.BudgetManager` to track the cumulative
+cost of ordered tests. Once the limit is reached the session stops.
+
 To start the demo web UI locally:
 
 ```bash


### PR DESCRIPTION
## Summary
- describe the BudgetManager in README
- mention the class path in docs
- document budget handling in installation guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'starlette')*

------
https://chatgpt.com/codex/tasks/task_e_686f87911508832aaec105055ad31991