### PR TITLE
Fix missing dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,6 +21,8 @@ httpx_ws==0.7.2
 starlette==0.46.2
 pydantic>=2.7,<3.0
 xmlschema==4.1.0
+PyYAML==6.0.1
+psutil==7.0.0
 
 # tracing
 opentelemetry-api==1.34.1


### PR DESCRIPTION
## Summary
- add PyYAML and psutil to requirements-dev

## Testing
- `pytest -q tests/test_panel.py::test_persona_plugin_loaded` *(fails: Persona chain 'optimist' not found)*
- `pytest -q` *(fails: Persona chain not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f842de054832a9c52aecb713c09c9