### PR TITLE
Add pydantic to runtime deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "sentence-transformers",
     "structlog",
     "filelock",
+    "pydantic>=2.11",
 ]
 
 [project.urls]

--- a/requirements.lock
+++ b/requirements.lock
@@ -387,6 +387,7 @@ protobuf==4.25.8
     # via googleapis-common-protos
 psutil==7.0.0
     # via
+    #   -r requirements-dev.txt
     #   dvc
     #   flufl-lock
 pycodestyle==2.14.0
@@ -432,8 +433,9 @@ python-dateutil==2.9.0.post0
     #   aiobotocore
     #   botocore
     #   celery
-pyyaml==6.0.2
+pyyaml==6.0.1
     # via
+    #   -r requirements-dev.txt
     #   huggingface-hub
     #   omegaconf
     #   pre-commit


### PR DESCRIPTION
## Summary
- add `pydantic>=2.11` to project dependencies
- regenerate `requirements.lock`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_686f94e867e4832aa026bf35c63756a6