### PR TITLE
Add docstring for Orchestrator class

### DIFF
--- a/sdb/orchestrator.py
+++ b/sdb/orchestrator.py
@@ -36,6 +36,7 @@ if os.getenv("SENTRY_DSN"):
 
 
 class Orchestrator:
+    """Coordinate panel actions while enforcing test budgets."""
     def __init__(
         self,
         panel: VirtualPanel,


### PR DESCRIPTION
## Summary
- document purpose of `Orchestrator` in `sdb/orchestrator.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f9a3f0a7c832aa800c186c10af03f