### PR TITLE
Refactor orchestrator turn handling

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -400,9 +400,11 @@ async def test_ws_budget_query_param(monkeypatch):
     class DummyOrchestrator:
         def __init__(self, *args, **kwargs):
             self.budget_manager = kwargs.get("budget_manager")
+            self.spent = 0.0
+            self.ordered_tests = []
 
         def run_turn(self, *_args, **_kwargs):
-            return ""
+            return "ok"
 
     monkeypatch.setattr(ui_app, "BudgetManager", DummyBudgetManager)
     monkeypatch.setattr(ui_app, "Orchestrator", DummyOrchestrator)


### PR DESCRIPTION
## Summary
- extract shared logic from `run_turn` and `run_turn_async`
- centralize bookkeeping in new `_execute_turn` helper
- adjust unit test stub orchestrator for websocket budget checks

## Testing
- `pytest tests/test_orchestrator.py::test_run_turn_async_budget_stops_session -q`
- `pytest tests/test_ui.py::test_ws_budget_query_param -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fa6e6e5dc832aae91e90ef35a1481