### PR TITLE
Document budget tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ bm = BudgetManager(costs, budget=500)
 orc = Orchestrator(panel, gatekeeper, budget_manager=bm)
 ```
 
+Use ``--budget-limit`` to set the cap when running the CLI in ``budgeted`` mode:
+
+```bash
+python -m dx0.cli --mode budgeted --budget-limit 1000 --case-file case.json
+```
+
+The Physician UI reads ``UI_BUDGET_LIMIT`` for the default limit and also
+accepts a ``budget`` query parameter on the WebSocket connection. See
+[`docs/budget_manager.md`](docs/budget_manager.md) for details.
+
 ---
 
 ## SDBench: Sequential Diagnosis Benchmark

--- a/docs/budget_manager.md
+++ b/docs/budget_manager.md
@@ -1,0 +1,30 @@
+# BudgetManager
+
+The `BudgetManager` service records the price of each ordered test using a
+`CostEstimator` and stops the session once the configured limit is reached. It
+also exposes the remaining budget so UIs can display a live cost summary.
+
+```python
+from sdb import BudgetManager, CostEstimator, Orchestrator
+
+costs = CostEstimator.load_from_csv("data/sdbench/costs.csv")
+bm = BudgetManager(costs, budget=500)
+orc = Orchestrator(panel, gatekeeper, budget_manager=bm)
+```
+
+The CLI creates a `BudgetManager` automatically when `--mode budgeted` is
+selected. Set the spending cap with `--budget-limit`:
+
+```bash
+python -m dx0.cli --mode budgeted --budget-limit 1000 --case-file case.json
+```
+
+The Physician UI reads `UI_BUDGET_LIMIT` to control the default cap for new
+sessions. You can override this for a single connection by passing a `budget`
+query parameter when opening the WebSocket:
+
+```bash
+export UI_BUDGET_LIMIT=750
+uvicorn sdb.ui.app:app --reload
+# Connect with ws://localhost:8000/api/v1/ws?token=<TOKEN>&budget=500
+```


### PR DESCRIPTION
## Summary
- document BudgetManager usage and configuration in the README
- add detailed docs/budget_manager.md with CLI and UI examples

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686faeecf31c832aa4e6b53986cd43df