### PR TITLE
Add UX backlog tasks

### DIFF
--- a/docs/ux_report.md
+++ b/docs/ux_report.md
@@ -1,0 +1,19 @@
+# Current UX Pain Points and Desired Outcomes
+
+The initial physician UI exposes only minimal functionality. Internal testing and early clinician feedback highlighted the following pain points:
+
+- **Unclear workflow** – ordering a test requires prefixing messages with `test:` yet the interface offers no hint about this syntax.
+- **Minimal feedback** – failures while loading a case or backend errors show up as browser alerts or silently in logs.
+- **Styling shortcomings** – the static two‑column grid lacks responsive behaviour, accessible color contrast and clear separation between panels.
+- **No session status** – users cannot easily determine which account is logged in or log out without refreshing the page.
+
+- **Conversation status** – clinicians were unsure when chats were complete or how to view the final cost.
+- **Expandable vignette** – they wanted to expand the case description while chatting.
+
+## Desired UX Outcomes
+
+- **Clarity** – add inline hints or a help panel describing available commands (`test:` and `diagnosis:`) and display the current username with a logout button.
+- **Accessibility** – adopt high‑contrast styles and ensure the layout works well on tablets. Form controls should include screen‑reader labels.
+- **Visual update** – migrate to a modern component framework (for example React with a UI library) and add collapsible panels so users can reference test results or the case summary without cluttering the chat.
+
+Implementing these improvements will make SDBench more approachable for clinicians evaluating the Gatekeeper approach.

--- a/tasks.yml
+++ b/tasks.yml
@@ -1460,3 +1460,40 @@ phases:
   command: null
   epic: Phase 6
   assigned_to: null
+- id: 86
+  title: Provide Final Cost Summary and Completion Notice
+  description: >
+    Show clinicians when the conversation has concluded and display a final
+    cost summary for the ordered tests.
+  component: ui
+  area: usability
+  dependencies: [58, 60]
+  priority: 2
+  status: pending
+  actionable_steps:
+    - Display an "interaction complete" banner after the final diagnosis.
+    - Summarize the total cost next to the banner.
+  acceptance_criteria:
+    - "Users see a clear end-of-session indicator with total cost." 
+  command: null
+  epic: User Experience (UX) & Accessibility
+  assigned_to: null
+
+- id: 87
+  title: Expandable Case Vignette
+  description: >
+    Allow the initial case description to be expanded or collapsed during the
+    chat so clinicians can reference details without losing context.
+  component: ui
+  area: usability
+  dependencies: [62]
+  priority: 3
+  status: pending
+  actionable_steps:
+    - Add a toggle that reveals or hides the vignette text.
+    - Ensure the control is keyboard accessible and labelled for screen readers.
+  acceptance_criteria:
+    - "Clinicians can show or hide the case vignette while chatting."
+  command: null
+  epic: User Experience (UX) & Accessibility
+  assigned_to: null


### PR DESCRIPTION
## Summary
- refine clinician UX notes
- include follow-up UI tasks in tasks.yml

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: starlette, pydantic, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6870413559c8832abb469702d8114b90