### PR TITLE
Document UI controls and close backlog item

### DIFF
--- a/docs/ui_feedback.md
+++ b/docs/ui_feedback.md
@@ -4,7 +4,7 @@
 
 The current demo UI exposes only the bare minimum functionality. Issues noted during internal testing include:
 
-- **Unclear workflow.** Ordering tests requires prefixing the message with `test:` which is not explained anywhere in the interface.
+- **Unclear workflow.** Early prototypes required prefixing the message with `test:` to order labs. The interface now provides an action dropdown and searchable test list.
 - **Minimal feedback.** Failures to load the case or backend errors appear only as browser alerts or silent log entries.
 - **Styling shortcomings.** The two-column grid is functional but lacks responsive design, accessible color contrast, or clear delineation between panels.
 - **No session status.** Users cannot easily tell which account is logged in or log out without refreshing the page.
@@ -15,7 +15,7 @@ Three clinicians tried the demo and echoed the concerns above. In particular the
 
 ## Proposed UX Outcomes
 
-- **Clarity.** Provide inline hints or a help panel explaining available commands (`test:` and `diagnosis:`). Include the current username and a logout button.
+- **Clarity.** Provide inline hints or a help panel explaining the Ask Question, Order Test, and Provide Diagnosis controls. Include the current username and a logout button.
 - **Accessibility.** Adopt higher-contrast styling and ensure the layout works on tablets. Screen reader labels should be added to form controls.
 - **Visual update.** Move to a modern component framework (e.g., React with a UI library) and add collapsible panels so users can focus on the chat while still referencing test results or the summary.
 

--- a/docs/ux_report.md
+++ b/docs/ux_report.md
@@ -2,7 +2,7 @@
 
 The initial physician UI exposes only minimal functionality. Internal testing and early clinician feedback highlighted the following pain points:
 
-- **Unclear workflow** – ordering a test requires prefixing messages with `test:` yet the interface offers no hint about this syntax.
+- **Unclear workflow** – early prototypes required prefixing messages with `test:` to order a lab. The UI now provides an action dropdown and searchable test list.
 - **Minimal feedback** – failures while loading a case or backend errors show up as browser alerts or silently in logs.
 - **Styling shortcomings** – the static two‑column grid lacks responsive behaviour, accessible color contrast and clear separation between panels.
 - **No session status** – users cannot easily determine which account is logged in or log out without refreshing the page.
@@ -11,7 +11,7 @@ Clinicians also found it confusing to know when a conversation was finished and 
 
 ## Desired UX Outcomes
 
-- **Clarity** – add inline hints or a help panel describing available commands (`test:` and `diagnosis:`) and display the current username with a logout button.
+- **Clarity** – add inline hints or a help panel describing available actions (question, test, diagnosis) and display the current username with a logout button.
 - **Accessibility** – adopt high‑contrast styles and ensure the layout works well on tablets. Form controls should include screen‑reader labels.
 - **Visual update** – migrate to a modern component framework (for example React with a UI library) and add collapsible panels so users can reference test results or the case summary without cluttering the chat.
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -852,7 +852,7 @@ phases:
   area: design
   dependencies: []
   priority: 2
-  status: pending
+  status: done
   actionable_steps:
     - Document current UX pain points and desired outcomes.
   acceptance_criteria:
@@ -871,7 +871,7 @@ phases:
   area: frontend
   dependencies: [56]
   priority: 3
-  status: pending
+  status: done
   actionable_steps:
     - Add buttons or a dropdown to select Ask Question, Order Test, or Provide Diagnosis.
     - Update WebSocket payloads based on the selected control.


### PR DESCRIPTION
## Summary
- clarify docs around ordering tests without `test:` prefix
- mark UI action controls task as complete

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687046e6f550832a9e50d9327e83f81f