### PR TITLE
Introduce Message models and validation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ export default function App() {
     const ws = new WebSocket(`ws://${location.host}/api/v1/ws?token=${token}`)
     ws.onmessage = ev => {
       const data = JSON.parse(ev.data)
+      if (data.error) return
       setLog(l => [...l, { sender: 'Gatekeeper', text: data.reply }])
       if (data.ordered_tests) setTests(data.ordered_tests)
     }

--- a/sdb/ui/static/main.js
+++ b/sdb/ui/static/main.js
@@ -95,6 +95,10 @@ function App() {
       const socket = new WebSocket(`ws://${location.host}/api/v1/ws?token=${data.token}`);
       socket.onmessage = (ev) => {
         const d = JSON.parse(ev.data);
+        if (d.error) {
+          setToast('Validation error');
+          return;
+        }
         let msgText = '';
         setLog(l => {
           const log = [...l];

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -4,7 +4,7 @@ import threading
 import uvicorn
 import asyncio
 import time
-from httpx_ws import aconnect_ws, WebSocketUpgradeError, WebSocketDisconnect
+from httpx_ws import aconnect_ws, WebSocketUpgradeError
 from starlette.testclient import TestClient
 from pathlib import Path
 
@@ -176,8 +176,8 @@ async def test_ws_schema_validation():
             f"ws://127.0.0.1:8002/api/v1/ws?token={token}", client
         ) as ws:
             await ws.send_json({"bad": "data"})
-            with pytest.raises(WebSocketDisconnect):
-                await ws.receive_json()
+            data = await ws.receive_json()
+            assert "error" in data
 
     server.should_exit = True
     thread.join()
@@ -203,8 +203,8 @@ async def test_ws_missing_field():
             f"ws://127.0.0.1:8003/api/v1/ws?token={token}", client
         ) as ws:
             await ws.send_json({"action": "question"})
-            with pytest.raises(WebSocketDisconnect):
-                await ws.receive_json()
+            data = await ws.receive_json()
+            assert "error" in data
 
     server.should_exit = True
     thread.join()
@@ -230,8 +230,8 @@ async def test_ws_invalid_action():
             f"ws://127.0.0.1:8004/api/v1/ws?token={token}", client
         ) as ws:
             await ws.send_json({"action": "invalid", "content": "hi"})
-            with pytest.raises(WebSocketDisconnect):
-                await ws.receive_json()
+            data = await ws.receive_json()
+            assert "error" in data
 
     server.should_exit = True
     thread.join()

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -20,6 +20,7 @@ export default function App() {
       const ws = new WebSocket(`/api/v1/ws?token=${token}`)
       ws.onmessage = ev => {
         const data = JSON.parse(ev.data)
+        if (data.error) return
         setLog(l => [...l, {sender: 'Gatekeeper', text: data.reply}])
         if (data.ordered_tests) setResults(data.ordered_tests)
       }


### PR DESCRIPTION
## Summary
- replace `ChatMessage`/`ChatResponse` with `MessageIn`/`MessageOut`
- handle websocket validation errors without closing the connection
- load template UI by default and handle error payloads in JS
- adjust tests for new schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871a1fda0c0832aaa7f0a8a303c14c5