### PR TITLE
Implement retrieval evaluation metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: flake8 .
       - name: Run tests
         run: pytest -q
+      - name: Retrieval evaluation
+        run: python scripts/retrieval_eval.py tests/retrieval_eval_cases.json --top-k 3
 
   docker:
     runs-on: ubuntu-latest

--- a/scripts/retrieval_eval.py
+++ b/scripts/retrieval_eval.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Evaluate retrieval accuracy for case documents."""
+
+import argparse
+from typing import Tuple
+
+from sdb.case_database import CaseDatabase
+from sdb.retrieval import load_retrieval_index
+
+
+def evaluate_retrieval(
+    db: CaseDatabase,
+    *,
+    top_k: int = 5,
+    retrieval_backend: str | None = None,
+) -> Tuple[float, float]:
+    """Compute recall@k and mean reciprocal rank for the database."""
+    docs: list[str] = []
+    doc_to_case: dict[str, str] = {}
+    for case in db.cases.values():
+        for para in case.full_text.split("\n"):
+            text = para.strip()
+            if text:
+                docs.append(text)
+                doc_to_case[text] = case.id
+
+    index = load_retrieval_index(docs, plugin_name=retrieval_backend)
+
+    hits = 0
+    rr_total = 0.0
+    total = 0
+    for case in db.cases.values():
+        query = case.summary.split(".")[0]
+        results = index.query(query, top_k=top_k)
+        total += 1
+        for rank, (doc, _score) in enumerate(results, start=1):
+            if doc_to_case.get(doc) == case.id:
+                hits += 1
+                rr_total += 1.0 / rank
+                break
+        else:
+            rr_total += 0.0
+    recall = hits / total if total else 0.0
+    mrr = rr_total / total if total else 0.0
+    return recall, mrr
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for command line invocation."""
+    parser = argparse.ArgumentParser(description="Evaluate retrieval accuracy")
+    parser.add_argument("cases", help="Path to cases JSON or CSV")
+    parser.add_argument("--top-k", type=int, default=5, help="Rank cutoff")
+    parser.add_argument("--backend", help="Retrieval backend", default=None)
+    args = parser.parse_args(argv)
+
+    if args.cases.endswith(".json"):
+        db = CaseDatabase.load_from_json(args.cases)
+    elif args.cases.endswith(".csv"):
+        db = CaseDatabase.load_from_csv(args.cases)
+    else:
+        raise ValueError("cases must be JSON or CSV")
+
+    recall, mrr = evaluate_retrieval(
+        db, top_k=args.top_k, retrieval_backend=args.backend
+    )
+    print(f"recall@{args.top_k}: {recall:.3f}")
+    print(f"mrr: {mrr:.3f}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tasks.yml
+++ b/tasks.yml
@@ -1169,7 +1169,7 @@ phases:
   area: evaluation
   dependencies: []
   priority: 3
-  status: pending
+  status: done
   actionable_steps:
     - Generate queries from case summaries or questions.
     - Compare returned passages against ground truth excerpts.

--- a/tests/retrieval_eval_cases.json
+++ b/tests/retrieval_eval_cases.json
@@ -1,0 +1,5 @@
+[
+  {"id": "1", "summary": "Patient has a cough and fever.", "full_text": "Patient reports a persistent cough and low-grade fever."},
+  {"id": "2", "summary": "Young male with chest pain after exercise.", "full_text": "A 25-year-old male experienced chest pain following intense exercise."},
+  {"id": "3", "summary": "Elderly female complaining of dizziness.", "full_text": "An elderly female presented with episodes of dizziness and nausea."}
+]

--- a/tests/test_retrieval_eval.py
+++ b/tests/test_retrieval_eval.py
@@ -1,0 +1,17 @@
+import json
+from sdb.case_database import CaseDatabase
+from scripts import retrieval_eval as rev
+
+
+def test_evaluate_retrieval(tmp_path):
+    cases = [
+        {"id": "1", "summary": "cough", "full_text": "patient cough"},
+        {"id": "2", "summary": "fever", "full_text": "high fever"},
+    ]
+    path = tmp_path / "cases.json"
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(cases, fh)
+    db = CaseDatabase.load_from_json(str(path))
+    recall, mrr = rev.evaluate_retrieval(db, top_k=1)
+    assert recall == 1.0
+    assert mrr == 1.0


### PR DESCRIPTION
## Summary
- add retrieval evaluation script to compute recall@k and MRR
- include sample cases for regression metric tracking
- test evaluation helper
- run retrieval metrics in CI
- mark task 71 complete

## Testing
- `pytest tests/test_retrieval_eval.py -q` *(fails: ModuleNotFoundError: No module named 'structlog')*
- `pre-commit run --files scripts/retrieval_eval.py tests/test_retrieval_eval.py .github/workflows/ci.yml tasks.yml tests/retrieval_eval_cases.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871dec75d0c832a915a30e5222cc8b9