### PR TITLE
Implement dark theme toggle

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -1210,7 +1210,7 @@ phases:
   area: design
   dependencies: [62]
   priority: 2
-  status: pending
+  status: done
   actionable_steps:
     - Define a dark palette in the chosen component library.
     - Provide a toggle or automatic detection of system theme.

--- a/tests/test_dark_theme.py
+++ b/tests/test_dark_theme.py
@@ -1,0 +1,33 @@
+"""Tests for dark theme color contrast."""
+
+import re
+from pathlib import Path
+
+HEX = r"#[0-9a-fA-F]{6}"
+
+
+def hex_to_rgb(hex_color: str):
+    r = int(hex_color[1:3], 16) / 255
+    g = int(hex_color[3:5], 16) / 255
+    b = int(hex_color[5:7], 16) / 255
+    return r, g, b
+
+
+def relative_luminance(rgb):
+    def channel(c):
+        return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+    r, g, b = rgb
+    return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+
+
+def contrast(c1: str, c2: str) -> float:
+    l1 = relative_luminance(hex_to_rgb(c1))
+    l2 = relative_luminance(hex_to_rgb(c2))
+    lighter, darker = max(l1, l2), min(l1, l2)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def test_theme_contrast():
+    css = Path("webui/src/index.css").read_text()
+    themes = {m.group(1): m.group(2) for m in re.finditer(r"--(foreground|background):\s*(%s)" % HEX, css)}
+    assert contrast(themes['foreground'], themes['background']) >= 4.5

--- a/webui/src/App.css
+++ b/webui/src/App.css
@@ -5,7 +5,7 @@
 }
 
 .panel {
-  border: 1px solid #ddd;
+  border: 1px solid var(--panel-border);
   margin-bottom: 1rem;
   padding: 0.5rem;
 }
@@ -23,6 +23,6 @@
 .log {
   height: 200px;
   overflow-y: auto;
-  border: 1px solid #ccc;
+  border: 1px solid var(--panel-border);
   padding: 0.5rem;
 }

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -10,7 +10,17 @@ export default function App() {
   const [results, setResults] = useState([])
   const [message, setMessage] = useState('')
   const [log, setLog] = useState([])
+  const [theme, setTheme] = useState(() => {
+    const stored = localStorage.getItem('theme')
+    if (stored === 'light' || stored === 'dark') return stored
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  })
   const wsRef = useRef(null)
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme
+    localStorage.setItem('theme', theme)
+  }, [theme])
 
   useEffect(() => {
     if (token) {
@@ -66,6 +76,7 @@ export default function App() {
   return (
     <div id="root">
       <h2>Gatekeeper Chat</h2>
+      <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>Switch to {theme === 'light' ? 'dark' : 'light'} mode</button>
       <CollapsiblePanel title="Case Summary">
         <p>{summary}</p>
       </CollapsiblePanel>

--- a/webui/src/index.css
+++ b/webui/src/index.css
@@ -3,14 +3,24 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  --background: #ffffff;
+  --foreground: #213547;
+  --panel-border: #ddd;
+  --button-bg: #f9f9f9;
+  --button-text: #213547;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+[data-theme='dark'] {
+  --background: #242424;
+  --foreground: #ffffff;
+  --panel-border: #444;
+  --button-bg: #1a1a1a;
+  --button-text: #ffffff;
 }
 
 a {
@@ -28,6 +38,8 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  color: var(--foreground);
+  background-color: var(--background);
 }
 
 h1 {
@@ -42,7 +54,8 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--button-bg);
+  color: var(--button-text);
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -54,15 +67,12 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    --background: #242424;
+    --foreground: #ffffff;
+    --panel-border: #444;
+    --button-bg: #1a1a1a;
+    --button-text: #ffffff;
   }
 }


### PR DESCRIPTION
## Summary
- add a dark mode palette using CSS variables
- toggle dark/light theme in React app and store preference
- mark the dark mode task as done
- verify theme colors meet WCAG AA with a new test

## Testing
- `pytest tests/test_dark_theme.py -q`
- `pytest -q` *(fails: 18 failed, 141 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6871e4c6ee78832ab353c2835a33f62f