### PR TITLE
Store evaluation metrics in SQLite

### DIFF
--- a/docs/metrics_db.md
+++ b/docs/metrics_db.md
@@ -1,0 +1,28 @@
+# Evaluation Metrics Database
+
+Session results from batch evaluations can be stored in SQLite for
+later analysis. Initialize an empty database:
+
+```bash
+python scripts/init_metrics_db.py results.db
+```
+
+Pass `--results-db results.db` when running `batch-eval` or the
+single-session CLI. Each run inserts a row with the case id, total
+cost, judge score, correctness flag and duration.
+
+Query average accuracy and cost across all runs:
+
+```sql
+SELECT AVG(score >= 4) AS accuracy, AVG(total_cost) AS avg_cost
+FROM results;
+```
+
+List the most expensive cases:
+
+```sql
+SELECT case_id, total_cost
+FROM results
+ORDER BY total_cost DESC
+LIMIT 5;
+```

--- a/scripts/init_metrics_db.py
+++ b/scripts/init_metrics_db.py
@@ -1,0 +1,18 @@
+"""Initialize an evaluation metrics SQLite database."""
+
+from __future__ import annotations
+
+import argparse
+
+from sdb.services import MetricsDB
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Create metrics SQLite file")
+    parser.add_argument("path", help="Destination database file")
+    args = parser.parse_args(argv)
+    MetricsDB(args.path)  # initialize schema
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -24,7 +24,7 @@ from .retrieval import (
     CrossEncoderReranker,
     get_retrieval_plugin,
 )
-from .services import BudgetManager, BudgetStore, ResultAggregator
+from .services import BudgetManager, BudgetStore, ResultAggregator, MetricsDB
 from .statistics import load_scores, permutation_test
 from .sqlite_db import load_from_sqlite, save_to_sqlite
 from .fhir_export import transcript_to_fhir, ordered_tests_to_fhir
@@ -59,6 +59,7 @@ __all__ = [
     "BudgetManager",
     "BudgetStore",
     "ResultAggregator",
+    "MetricsDB",
     "Evaluator",
     "convert_directory",
     "translate_directory",

--- a/sdb/services/__init__.py
+++ b/sdb/services/__init__.py
@@ -3,5 +3,6 @@
 from .budget import BudgetManager
 from .budget_store import BudgetStore
 from .results import ResultAggregator
+from .metrics_db import MetricsDB
 
-__all__ = ["BudgetManager", "BudgetStore", "ResultAggregator"]
+__all__ = ["BudgetManager", "BudgetStore", "ResultAggregator", "MetricsDB"]

--- a/sdb/services/metrics_db.py
+++ b/sdb/services/metrics_db.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""SQLite storage for session evaluation metrics."""
+
+import sqlite3
+from typing import Iterable
+
+from ..evaluation import SessionResult
+
+
+class MetricsDB:
+    """Persist :class:`SessionResult` records in SQLite."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self._init_db()
+
+    def _init_db(self) -> None:
+        conn = sqlite3.connect(self.path)
+        cur = conn.cursor()
+        cur.execute(
+            (
+                "CREATE TABLE IF NOT EXISTS results ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                "case_id TEXT,"
+                "total_cost REAL,"
+                "score INTEGER,"
+                "correct INTEGER,"
+                "duration REAL,"
+                "ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+                ")"
+            )
+        )
+        conn.commit()
+        conn.close()
+
+    def record(self, case_id: str, result: SessionResult) -> None:
+        """Insert a single session ``result`` for ``case_id``."""
+        conn = sqlite3.connect(self.path)
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO results (case_id, total_cost, score, correct, duration) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                case_id,
+                result.total_cost,
+                result.score,
+                int(result.correct),
+                result.duration,
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+    def bulk_record(self, rows: Iterable[tuple[str, SessionResult]]) -> None:
+        """Insert multiple ``(case_id, result)`` rows."""
+        conn = sqlite3.connect(self.path)
+        cur = conn.cursor()
+        cur.executemany(
+            "INSERT INTO results (case_id, total_cost, score, correct, duration) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                (
+                    case_id,
+                    res.total_cost,
+                    res.score,
+                    int(res.correct),
+                    res.duration,
+                )
+                for case_id, res in rows
+            ],
+        )
+        conn.commit()
+        conn.close()

--- a/tests/test_metrics_db.py
+++ b/tests/test_metrics_db.py
@@ -1,0 +1,17 @@
+from sdb.services.metrics_db import MetricsDB
+from sdb.evaluation import SessionResult
+
+
+def test_metrics_db_records(tmp_path):
+    db_path = tmp_path / "m.db"
+    db = MetricsDB(str(db_path))
+    result = SessionResult(total_cost=10.0, score=5, correct=True, duration=1.0)
+    db.record("c1", result)
+    import sqlite3
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT case_id, total_cost, score, correct, duration FROM results")
+    row = cur.fetchone()
+    conn.close()
+    assert row == ("c1", 10.0, 5, 1, 1.0)


### PR DESCRIPTION
## Summary
- add `MetricsDB` for persisting session metrics
- initialize metric database with `init_metrics_db.py`
- record metrics after evaluations
- test metric storage and update CLI tests
- document querying the metrics database

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f3d7abc4832a960ad988da9cfcac