### PR TITLE
Add plugin loader for cost estimators

### DIFF
--- a/docs/cost_estimator_plugins.md
+++ b/docs/cost_estimator_plugins.md
@@ -1,0 +1,34 @@
+# Cost Estimator Plugins
+
+Dx0 can load alternative pricing logic through Python entry points. Each plugin
+registers a callable under the `dx0.cost_estimators` group that accepts the path
+to a pricing table and returns a `CostEstimator` instance.
+
+## Writing a Plugin
+
+1. Implement a loader function:
+
+```python
+from sdb.cost_estimator import CostEstimator, CptCost
+
+def my_estimator(path: str) -> CostEstimator:
+    # load prices from `path` or ignore it and call an API
+    table = {"cbc": CptCost("100", 1.0)}
+    return CostEstimator(table)
+```
+
+2. Declare the entry point in your `pyproject.toml`:
+
+```toml
+[project.entry-points."dx0.cost_estimators"]
+my-estimator = "my_package:my_estimator"
+```
+
+3. Install the package so `importlib.metadata` can discover the entry point:
+
+```bash
+pip install -e path/to/my_package
+```
+
+Select the plugin with `--cost-estimator` or set `SDB_COST_ESTIMATOR` in the
+environment. The default `csv` plugin uses `CostEstimator.load_from_csv`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,6 @@ optimist = "sdb.plugins.optimist_plugin:optimistic_chain"
 [project.entry-points."sdb.retrieval_plugins"]
 sentence-transformer = "sdb.retrieval:SentenceTransformerIndex"
 faiss = "sdb.retrieval:FaissIndex"
+
+[project.entry-points."dx0.cost_estimators"]
+csv = "sdb.cost_estimator:load_csv_estimator"

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -1,7 +1,7 @@
 """SDBench framework and MAI-DxO skeleton implementation."""
 
 from .case_database import Case, CaseDatabase, SQLiteCaseDatabase
-from .cost_estimator import CostEstimator, CptCost
+from .cost_estimator import CostEstimator, CptCost, load_cost_estimator
 from .gatekeeper import Gatekeeper
 from .judge import Judge
 from .protocol import ActionType, build_action
@@ -42,6 +42,7 @@ __all__ = [
     "SQLiteCaseDatabase",
     "CostEstimator",
     "CptCost",
+    "load_cost_estimator",
     "Gatekeeper",
     "Judge",
     "ActionType",

--- a/sdb/config.py
+++ b/sdb/config.py
@@ -16,6 +16,7 @@ class Settings(BaseModel):
     semantic_retrieval: bool = False
     cross_encoder_model: Optional[str] = None
     retrieval_backend: Optional[str] = None
+    cost_estimator_plugin: Optional[str] = None
     retrieval_cache_ttl: int = 300
     case_db: Optional[str] = None
     case_db_sqlite: Optional[str] = None
@@ -77,6 +78,8 @@ def load_settings(path: str | None = None) -> Settings:
         data["parallel_personas"] = env("SDB_PARALLEL_PERSONAS").lower() == "true"
     if "retrieval_backend" not in data and env("SDB_RETRIEVAL_BACKEND"):
         data["retrieval_backend"] = env("SDB_RETRIEVAL_BACKEND")
+    if "cost_estimator_plugin" not in data and env("SDB_COST_ESTIMATOR"):
+        data["cost_estimator_plugin"] = env("SDB_COST_ESTIMATOR")
     if "retrieval_cache_ttl" not in data and env("SDB_RETRIEVAL_CACHE_TTL"):
         try:
             data["retrieval_cache_ttl"] = int(env("SDB_RETRIEVAL_CACHE_TTL"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -632,8 +632,9 @@ def test_cli_cost_table_custom(monkeypatch, tmp_path):
     class DummyCostEstimator:
         pass
 
-    def dummy_load(path: str) -> DummyCostEstimator:
+    def dummy_load(path: str, plugin_name: str = "csv") -> DummyCostEstimator:
         captured["path"] = path
+        captured["plugin"] = plugin_name
         return DummyCostEstimator()
 
     class DummyBudgetManager:
@@ -650,7 +651,7 @@ def test_cli_cost_table_custom(monkeypatch, tmp_path):
         def run_turn(self, *_args, **_kwargs):
             return ""
 
-    monkeypatch.setattr(cli.CostEstimator, "load_from_csv", staticmethod(dummy_load))
+    monkeypatch.setattr(cli, "load_cost_estimator", dummy_load)
     monkeypatch.setattr(cli, "BudgetManager", DummyBudgetManager)
     monkeypatch.setattr(cli, "Orchestrator", DummyOrchestrator)
     monkeypatch.setattr(cli, "start_metrics_server", lambda *_: None)
@@ -671,6 +672,7 @@ def test_cli_cost_table_custom(monkeypatch, tmp_path):
 
     assert captured["path"] == str(cost_file)
     assert isinstance(captured["estimator"], DummyCostEstimator)
+    assert captured["plugin"] == "csv"
 
 
 def test_batch_eval_ollama_base_url(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- support `dx0.cost_estimators` entry points
- load estimator plugins through the CLI
- document writing custom cost estimator plugins

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'starlette')*

------
https://chatgpt.com/codex/tasks/task_e_68720b35593c832ab6aa8ec69eb1ff03