### PR TITLE
Implement group-based user roles

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16,7 +16,6 @@ from sdb import WeightedVoter  # noqa: F401 - exposed for tests
 from sdb import (
     BudgetManager,
     CaseDatabase,
-    CostEstimator,
     load_cost_estimator,
     DiagnosisResult,
     Evaluator,
@@ -313,7 +312,9 @@ def batch_eval_main(argv: list[str]) -> None:
     cost_path = args.cost_table or args.costs
     if cost_path is None:
         parser.error("--cost-table or --costs is required")
-    cost_estimator = load_cost_estimator(cost_path, plugin_name=args.cost_estimator or "csv")
+    cost_estimator = load_cost_estimator(
+        cost_path, plugin_name=args.cost_estimator or "csv"
+    )
     judge = Judge(rubric)
     evaluator = Evaluator(
         judge,
@@ -664,6 +665,7 @@ def manage_users_main(argv: list[str]) -> None:
     add_p = sub.add_parser("add", help="Add a user")
     add_p.add_argument("username")
     add_p.add_argument("--password", default=None, help="User password")
+    add_p.add_argument("--group", default="default", help="User group")
 
     rem_p = sub.add_parser("remove", help="Remove a user")
     rem_p.add_argument("username")
@@ -681,7 +683,7 @@ def manage_users_main(argv: list[str]) -> None:
     if args.cmd == "add":
         pwd = args.password or getpass.getpass("Password: ")
         hashed = bcrypt.hashpw(pwd.encode(), bcrypt.gensalt()).decode()
-        users[args.username] = hashed
+        users[args.username] = {"password": hashed, "group": args.group}
         data["users"] = users
         os.makedirs(os.path.dirname(args.file), exist_ok=True)
         with open(args.file, "w", encoding="utf-8") as fh:
@@ -943,7 +945,9 @@ def main() -> None:
     )
     gatekeeper.register_test_result("complete blood count", "normal")
 
-    cost_estimator = load_cost_estimator(cost_path, plugin_name=args.cost_estimator or "csv")
+    cost_estimator = load_cost_estimator(
+        cost_path, plugin_name=args.cost_estimator or "csv"
+    )
 
     with open(args.rubric, "r", encoding="utf-8") as fh:
         rubric = json.load(fh)

--- a/docs/add_users.md
+++ b/docs/add_users.md
@@ -20,8 +20,12 @@ Edit the `users` mapping in `sdb/ui/users.yml` to add a new entry:
 
 ```yaml
 users:
-  physician: "$2b$12$existinghash..."
-  newuser: "$2b$12$generatedhash..."
+  physician:
+    password: "$2b$12$existinghash..."
+    group: admin
+  newuser:
+    password: "$2b$12$generatedhash..."
+    group: default
 ```
 
 ## Custom Credential Paths

--- a/sdb/ui/users.yml
+++ b/sdb/ui/users.yml
@@ -1,2 +1,4 @@
 users:
-  physician: "$2b$12$9slz7NqLC0Oz5cugpXBGH.zwoj6xXH4E7zmf59MVlECfJ2O86LyM2"
+  physician:
+    password: "$2b$12$9slz7NqLC0Oz5cugpXBGH.zwoj6xXH4E7zmf59MVlECfJ2O86LyM2"
+    group: admin

--- a/tasks.yml
+++ b/tasks.yml
@@ -1391,7 +1391,7 @@ phases:
   area: authentication
   dependencies: [68]
   priority: 3
-  status: pending
+  status: done
   actionable_steps:
     - Extend the credentials model with a group field.
     - Enforce permissions when accessing protected endpoints.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1115,7 +1115,9 @@ def test_manage_users_command(tmp_path):
     with open(cred, "r", encoding="utf-8") as fh:
         data = yaml.safe_load(fh)
     assert "alice" in data.get("users", {})
-    assert data["users"]["alice"].startswith("$2b$")
+    entry = data["users"]["alice"]
+    assert isinstance(entry, dict)
+    assert entry["password"].startswith("$2b$")
 
     cmd_list = [
         sys.executable,

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -369,9 +369,14 @@ async def test_token_cleanup(tmp_path):
 
 def test_fhir_transcript_endpoint():
     client = TestClient(app)
+    token = client.post(
+        "/api/v1/login",
+        json={"username": "physician", "password": "secret"},
+    ).json()["access_token"]
     data = [["panel", "hi"], ["gatekeeper", "hello"]]
     res = client.post(
         "/api/v1/fhir/transcript",
+        headers={"Authorization": f"Bearer {token}"},
         json={"transcript": data, "patient_id": "p1"},
     )
     assert res.status_code == 200
@@ -382,8 +387,13 @@ def test_fhir_transcript_endpoint():
 
 def test_fhir_tests_endpoint():
     client = TestClient(app)
+    token = client.post(
+        "/api/v1/login",
+        json={"username": "physician", "password": "secret"},
+    ).json()["access_token"]
     res = client.post(
         "/api/v1/fhir/tests",
+        headers={"Authorization": f"Bearer {token}"},
         json={"tests": ["cbc"], "patient_id": "p2"},
     )
     assert res.status_code == 200


### PR DESCRIPTION
## Summary
- extend credentials with group field and adjust loader
- add permission checks via `require_group` dependency
- store group info in session database
- update CLI user management for groups
- require authorization for FHIR export endpoints
- document new YAML format and mark task 82 done

## Testing
- `black sdb/ui/app.py sdb/ui/session_store.py cli.py tests/test_ui.py tests/test_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872151ad798832aa3ccd8e6d8123bc5