### PR TITLE
Add CLI token login and refresh

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -42,6 +42,8 @@ from sdb import (
     transcript_to_fhir,
 )
 from sdb.config import load_settings, settings
+from sdb import token
+from sdb.token import TOKEN_PATH
 
 _ = WeightedVoter
 
@@ -648,6 +650,30 @@ def filter_cases_main(argv: list[str]) -> None:
             json.dump(selected, fh, indent=2)
 
 
+def login_main(argv: list[str]) -> None:
+    """Authenticate with the API and store a session token."""
+
+    parser = argparse.ArgumentParser(description="Login to Dx0 API")
+    parser.add_argument("--api-url", default="http://localhost:8000/api/v1")
+    parser.add_argument("--username", required=True)
+    parser.add_argument("--password", default=None)
+    parser.add_argument(
+        "--token-file",
+        default=str(TOKEN_PATH),
+        help="Path to store the session token",
+    )
+    args = parser.parse_args(argv)
+
+    pwd = args.password or getpass.getpass("Password: ")
+    token.login(
+        args.api_url,
+        args.username,
+        pwd,
+        path=Path(args.token_file),
+    )
+    print(f"Token saved to {args.token_file}")
+
+
 def manage_users_main(argv: list[str]) -> None:
     """Add, remove or list web UI users."""
 
@@ -1042,6 +1068,8 @@ if __name__ == "__main__":
         annotate_case_main(sys.argv[2:])
     elif len(sys.argv) > 1 and sys.argv[1] == "filter-cases":
         filter_cases_main(sys.argv[2:])
+    elif len(sys.argv) > 1 and sys.argv[1] == "login":
+        login_main(sys.argv[2:])
     elif len(sys.argv) > 1 and sys.argv[1] == "manage-users":
         manage_users_main(sys.argv[2:])
     else:

--- a/docs/cli_tokens.md
+++ b/docs/cli_tokens.md
@@ -1,0 +1,10 @@
+# CLI Session Tokens
+
+The `dx0 login` command stores your API access and refresh tokens in
+`~/.dx0/token.json` by default. The file permissions are set so only your
+account can read it (`0600`). Avoid checking this file into version control or
+sharing it with other users. If you need to use a different location, pass the
+`--token-file` option when logging in.
+
+Tokens are short lived. The helper functions in `sdb.token` automatically refresh
+the access token using the stored refresh token when necessary.

--- a/sdb/token.py
+++ b/sdb/token.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Utility functions for CLI session tokens."""
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+import httpx
+import jwt
+
+TOKEN_PATH = Path.home() / ".dx0" / "token.json"
+
+
+def _save_tokens(access: str, refresh: str, path: Path = TOKEN_PATH) -> None:
+    """Persist ``access`` and ``refresh`` tokens to ``path`` with expiry."""
+
+    payload = jwt.decode(access, options={"verify_signature": False})
+    expires = int(payload.get("exp", 0))
+    os.makedirs(path.parent, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(
+            {
+                "access_token": access,
+                "refresh_token": refresh,
+                "expires": expires,
+            },
+            fh,
+        )
+    os.chmod(path, 0o600)
+
+
+def load_tokens(path: Path = TOKEN_PATH) -> Optional[dict]:
+    """Return token data loaded from ``path`` if it exists."""
+
+    if not path.exists():
+        return None
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def login(
+    api_url: str, username: str, password: str, *, path: Path = TOKEN_PATH
+) -> dict:
+    """Authenticate with ``api_url`` and store the returned tokens."""
+
+    res = httpx.post(
+        f"{api_url.rstrip('/')}/login",
+        json={"username": username, "password": password},
+        timeout=30,
+    )
+    res.raise_for_status()
+    data = res.json()
+    _save_tokens(data["access_token"], data["refresh_token"], path)
+    return data
+
+
+def refresh(api_url: str, refresh_token: str, *, path: Path = TOKEN_PATH) -> dict:
+    """Refresh ``refresh_token`` via ``api_url`` and persist new tokens."""
+
+    res = httpx.post(
+        f"{api_url.rstrip('/')}/refresh",
+        json={"refresh_token": refresh_token},
+        timeout=30,
+    )
+    res.raise_for_status()
+    data = res.json()
+    _save_tokens(data["access_token"], data["refresh_token"], path)
+    return data
+
+
+def get_access_token(api_url: str, *, path: Path = TOKEN_PATH) -> str:
+    """Return a valid access token, refreshing if necessary."""
+
+    data = load_tokens(path)
+    if not data:
+        raise RuntimeError("No saved tokens. Run 'dx0 login' first.")
+    if int(data.get("expires", 0)) <= int(time.time()):
+        data = refresh(api_url, data["refresh_token"], path=path)
+    return data["access_token"]

--- a/tasks.yml
+++ b/tasks.yml
@@ -1411,7 +1411,7 @@ phases:
   area: security
   dependencies: [74]
   priority: 2
-  status: pending
+  status: done
   actionable_steps:
     - Add `dx0 login` command that obtains a token via the API.
     - Automatically refresh the token when expired.

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -1,0 +1,41 @@
+import json
+import time
+
+import httpx
+import pytest
+from starlette.testclient import TestClient
+
+import sdb.ui.app as ui_app
+from sdb import token
+
+app = ui_app.app
+
+
+def fake_post_factory(client):
+    def _post(url, json=None, timeout=30):
+        path = url.replace("http://testserver/api/v1", "/api/v1")
+        return client.post(path, json=json)
+    return _post
+
+
+def test_login_and_refresh(tmp_path, monkeypatch):
+    client = TestClient(app)
+    monkeypatch.setattr(httpx, "post", fake_post_factory(client))
+    tok_file = tmp_path / "tok.json"
+    monkeypatch.setattr(token, "TOKEN_PATH", tok_file)
+
+    token.login("http://testserver/api/v1", "physician", "secret")
+    assert tok_file.exists()
+    data = json.load(open(tok_file))
+    assert "access_token" in data
+    old_refresh = data["refresh_token"]
+
+    # expire token
+    data["expires"] = int(time.time()) - 1
+    with open(tok_file, "w") as fh:
+        json.dump(data, fh)
+
+    new_token = token.get_access_token("http://testserver/api/v1")
+    assert new_token != ""
+    data2 = json.load(open(tok_file))
+    assert data2["refresh_token"] != old_refresh


### PR DESCRIPTION
## Summary
- add new `dx0 login` command to retrieve a short‑lived token
- automatically refresh CLI tokens
- document safe storage for tokens
- mark task 83 complete

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'starlette')*

------
https://chatgpt.com/codex/tasks/task_e_6872216955a0832ab4dcf0ea4ebbc8ab