### PR TITLE
Document advanced orchestrator settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,36 @@ while not orc.finished:
 print(orc.final_diagnosis, orc.spent)
 ```
 
+### Advanced Orchestrator Settings
+
+Dx0 exposes several configuration hooks for fine-tuning panel behavior.
+
+**Budgets**
+
+- Pass a `BudgetManager` to :class:`Orchestrator` to enforce a spending limit.
+- Use the `--budget` flag when running in budgeted mode or `--budget-limit` for
+  other modes. The Physician UI reads `UI_BUDGET_LIMIT` for its default cap.
+
+```python
+costs = CostEstimator.load_from_csv("data/sdbench/costs.csv")
+bm = BudgetManager(costs, budget=250)
+orc = Orchestrator(VirtualPanel(), gatekeeper, budget_manager=bm)
+```
+
+**Personas**
+
+- Custom persona chains can be loaded from plugins registered under the
+  ``dx0.personas`` entry point group. Instantiate a panel with
+  ``VirtualPanel(persona_chain="optimist")`` or your own plugin name.
+- See [docs/persona_plugins.md](docs/persona_plugins.md) for plugin creation
+  details.
+
+```python
+panel = VirtualPanel(persona_chain="my-chain")
+orc = Orchestrator(panel, gatekeeper)
+```
+
+
 ### Running Tests
 
 The test suite depends on additional packages such as `httpx`,

--- a/sdb/token.py
+++ b/sdb/token.py
@@ -14,9 +14,10 @@ import jwt
 TOKEN_PATH = Path.home() / ".dx0" / "token.json"
 
 
-def _save_tokens(access: str, refresh: str, path: Path = TOKEN_PATH) -> None:
+def _save_tokens(access: str, refresh: str, path: Path | None = None) -> None:
     """Persist ``access`` and ``refresh`` tokens to ``path`` with expiry."""
 
+    path = path or TOKEN_PATH
     payload = jwt.decode(access, options={"verify_signature": False})
     expires = int(payload.get("exp", 0))
     os.makedirs(path.parent, exist_ok=True)
@@ -32,9 +33,10 @@ def _save_tokens(access: str, refresh: str, path: Path = TOKEN_PATH) -> None:
     os.chmod(path, 0o600)
 
 
-def load_tokens(path: Path = TOKEN_PATH) -> Optional[dict]:
+def load_tokens(path: Path | None = None) -> Optional[dict]:
     """Return token data loaded from ``path`` if it exists."""
 
+    path = path or TOKEN_PATH
     if not path.exists():
         return None
     with open(path, "r", encoding="utf-8") as fh:
@@ -42,10 +44,11 @@ def load_tokens(path: Path = TOKEN_PATH) -> Optional[dict]:
 
 
 def login(
-    api_url: str, username: str, password: str, *, path: Path = TOKEN_PATH
+    api_url: str, username: str, password: str, *, path: Path | None = None
 ) -> dict:
     """Authenticate with ``api_url`` and store the returned tokens."""
 
+    path = path or TOKEN_PATH
     res = httpx.post(
         f"{api_url.rstrip('/')}/login",
         json={"username": username, "password": password},
@@ -57,9 +60,10 @@ def login(
     return data
 
 
-def refresh(api_url: str, refresh_token: str, *, path: Path = TOKEN_PATH) -> dict:
+def refresh(api_url: str, refresh_token: str, *, path: Path | None = None) -> dict:
     """Refresh ``refresh_token`` via ``api_url`` and persist new tokens."""
 
+    path = path or TOKEN_PATH
     res = httpx.post(
         f"{api_url.rstrip('/')}/refresh",
         json={"refresh_token": refresh_token},
@@ -71,9 +75,10 @@ def refresh(api_url: str, refresh_token: str, *, path: Path = TOKEN_PATH) -> dic
     return data
 
 
-def get_access_token(api_url: str, *, path: Path = TOKEN_PATH) -> str:
+def get_access_token(api_url: str, *, path: Path | None = None) -> str:
     """Return a valid access token, refreshing if necessary."""
 
+    path = path or TOKEN_PATH
     data = load_tokens(path)
     if not data:
         raise RuntimeError("No saved tokens. Run 'dx0 login' first.")

--- a/tasks.yml
+++ b/tasks.yml
@@ -1431,7 +1431,7 @@ phases:
   area: documentation
   dependencies: []
   priority: 3
-  status: pending
+  status: done
   actionable_steps:
     - Describe configuration options for budgets and personas.
     - Provide examples for plugin-based panels.

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -2,7 +2,6 @@ import json
 import time
 
 import httpx
-import pytest
 from starlette.testclient import TestClient
 
 import sdb.ui.app as ui_app


### PR DESCRIPTION
## Summary
- document budget and persona settings in README
- mark related documentation task done
- allow token helpers to accept dynamic paths
- fix flake8 lint in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687226bf11b8832abe58429afd328b34