### PR TITLE
Implement plugin metadata validation

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -24,6 +24,7 @@ from .retrieval import (
     CrossEncoderReranker,
     get_retrieval_plugin,
 )
+from .plugins import PluginInfo, validate_plugins
 from .services import BudgetManager, BudgetStore, ResultAggregator, MetricsDB
 from .statistics import load_scores, permutation_test
 from .sqlite_db import load_from_sqlite, save_to_sqlite
@@ -88,4 +89,6 @@ __all__ = [
     "async_batch_evaluate",
     "batch_evaluate",
     "configure_logging",
+    "PluginInfo",
+    "validate_plugins",
 ]

--- a/sdb/plugins/__init__.py
+++ b/sdb/plugins/__init__.py
@@ -1,1 +1,65 @@
-"""Built-in persona plugins."""
+"""Plugin utilities and built-in persona plugins."""
+
+from __future__ import annotations
+
+from importlib import metadata
+from typing import Iterable, List
+
+import structlog
+from pydantic import BaseModel, ValidationError, field_validator
+
+logger = structlog.get_logger(__name__)
+
+# Entry point groups exposing pluggable components
+PLUGIN_GROUPS = (
+    "dx0.personas",
+    "sdb.retrieval_plugins",
+    "dx0.cost_estimators",
+)
+
+
+class PluginInfo(BaseModel):
+    """Metadata describing an installed plugin."""
+
+    name: str
+    version: str
+    entry_point: str
+
+    @field_validator("name", "version", "entry_point")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("must not be empty")
+        return value
+
+
+def validate_plugins(groups: Iterable[str] = PLUGIN_GROUPS) -> List[PluginInfo]:
+    """Return metadata for plugins registered under ``groups``.
+
+    Raises
+    ------
+    RuntimeError
+        If a plugin is missing required metadata.
+    """
+
+    infos: List[PluginInfo] = []
+    for group in groups:
+        for ep in metadata.entry_points(group=group):
+            dist = ep.dist
+            data = {
+                "name": getattr(dist, "name", ""),
+                "version": getattr(dist, "version", ""),
+                "entry_point": ep.value,
+            }
+            try:
+                info = PluginInfo.model_validate(data)
+            except ValidationError as exc:  # pragma: no cover - sanity check
+                raise RuntimeError(
+                    f"Invalid plugin metadata for '{ep.value}': {exc}"
+                ) from exc
+            infos.append(info)
+    return infos
+
+
+# Validate plugins on import to fail fast when misconfigured
+validate_plugins()

--- a/tasks.yml
+++ b/tasks.yml
@@ -1450,7 +1450,7 @@ phases:
   area: validation
   dependencies: []
   priority: 2
-  status: pending
+  status: done
   actionable_steps:
     - Create `PluginInfo` model with name, version, and entry point.
     - Validate registered plugins before use.

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+import pytest
+
+from sdb.plugins import PluginInfo, validate_plugins
+
+
+def test_validate_plugins_returns_info():
+    infos = validate_plugins()
+    assert any(isinstance(i, PluginInfo) for i in infos)
+
+
+def test_validate_plugins_missing_fields(monkeypatch):
+    class DummyEP:
+        def __init__(self):
+            self.name = "bad"
+            self.value = "badpkg:obj"
+            self.group = "dx0.personas"
+            self.dist = SimpleNamespace(name="badpkg", version="")
+
+    def fake_entry_points(group=None):
+        return [DummyEP()] if group == "dx0.personas" else []
+
+    monkeypatch.setattr(
+        validate_plugins.__globals__["metadata"], "entry_points", fake_entry_points
+    )
+    with pytest.raises(RuntimeError):
+        validate_plugins(["dx0.personas"])


### PR DESCRIPTION
## Summary
- define `PluginInfo` pydantic model
- add `validate_plugins` utility and call it at import
- expose plugin validation from package root
- document completed task in `tasks.yml`
- test plugin validation logic

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68722f9f31c0832a820a9c74b2fb5ab1