### PR TITLE
Update tasks with testing and CLI items

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -257,6 +257,13 @@ phases:
         description: "Visualize trade-offs by plotting the Pareto frontier."
         done: true
 
+      - id: 24
+        title: "Expand Evaluation Framework Tests"
+        description: >
+          Add unit tests for the Judge agent, CostEstimator, and evaluation metrics generation.
+        labels: [test, evaluation]
+        status: pending
+
   - name: "Phase 3: Production Readiness & Advanced Features"
     tasks:
       - id: "T23"
@@ -309,6 +316,23 @@ phases:
           - "Develop a 'Meta-Panel' agent that reviews the diagnoses and reasoning chains from all parallel runs to produce a final, synthesized diagnosis."
           - "Explore cost-adjusted utility functions to select a final diagnosis that optimizes for both accuracy and cost-effectiveness."
         done: true
+
+      - id: 92
+        title: "Centralized Error Handling and Logging"
+        description: >
+          Introduce a unified error handling framework with custom exceptions and structured logging.
+        component: backend
+        area: robustness
+        priority: 2
+        status: pending
+      - id: 93
+        title: "Refactor CLI with Typer"
+        description: >
+          Replace argparse with Typer to provide a modern CLI with type validation and rich help output.
+        component: cli
+        area: usability
+        priority: 2
+        status: pending
 
   - name: "Phase 4: LLM Integration and Production Hardening"
     tasks:


### PR DESCRIPTION
## Summary
- add pending task for evaluation framework tests
- add tasks for centralized error handling and Typer-based CLI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'starlette')*
- `pip install -r requirements-dev.txt` *(fails to finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687259a69ebc832aa83a210c46aa26f5