### PR TITLE
Add getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ source venv/bin/activate
 pip install -r requirements.lock
 ```
 
+For details on creating a development environment and running the test suite,
+see [docs/getting_started.md](docs/getting_started.md).
+
 See [Dependency Management](docs/dependency_updates.md) for details on
 updating and auditing requirements. You can build a Docker image using the
 multi-stage `Dockerfile`:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,47 @@
+# Getting Started
+
+This short guide walks through setting up a development environment for Dx0 and SDBench. It covers creating a Python virtual environment, installing dependencies and running the test suite.
+
+## Environment Setup
+
+Create and activate a virtual environment with Python 3.12 or later:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+Set `OPENAI_API_KEY` if you intend to query the OpenAI API:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+If you prefer to run models locally, start an [Ollama](https://github.com/jmorganca/ollama) server (``ollama serve``) and pass ``--llm-provider ollama`` to the CLI.
+
+## Installing Dependencies
+
+All packages are pinned in `requirements.lock`. Install them with:
+
+```bash
+pip install -r requirements.lock
+```
+
+For an editable installation of the library itself run:
+
+```bash
+pip install -e .
+```
+
+This provides the `dx0` and `sdbench` modules on your `PYTHONPATH` and installs additional developer tools such as `pytest`.
+
+## Running Tests
+
+Execute the unit tests from the repository root:
+
+```bash
+pytest -q
+```
+
+The suite relies on packages listed in `requirements.lock`. All tests should pass before submitting a pull request.
+


### PR DESCRIPTION
## Summary
- document environment setup, dependency installation, and running tests
- link the new guide from `README.md`

## Testing
- `pytest -q` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6872e95652a8832a9af395a9320f05d0