### PR TITLE
Add NEJM fine-tuning scripts and HF model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ python -m dx0.cli \
   --ollama-base-url http://localhost:11434 ...
 ```
 
+For a locally fine-tuned Hugging Face model, use `--llm-provider hf-local` and
+point `--hf-model` to the model directory:
+
+```bash
+python -m dx0.cli \
+  --llm-provider hf-local \
+  --hf-model /models/nejm-lora ...
+```
+
 ### Configuration
 
 You can load common settings from a YAML file using `--config`:
@@ -146,6 +155,7 @@ You can load common settings from a YAML file using `--config`:
 ```yaml
 openai_api_key: sk-your-key
 openai_model: gpt-4
+hf_model: /models/nejm-lora
 ollama_base_url: http://localhost:11434
 metrics_port: 8000
 case_db: data/sdbench/cases

--- a/docs/finetuning.md
+++ b/docs/finetuning.md
@@ -1,0 +1,34 @@
+# Fine-Tuning a Domain-Specific Model
+
+This guide outlines how to train a Hugging Face model on the NEJM case corpus
+and integrate it with Dx0.
+
+1. **Prepare the dataset**
+   Use `scripts/prepare_finetune.py` to convert the JSON cases into a JSONL file
+   suitable for language model training:
+
+   ```bash
+   python scripts/prepare_finetune.py data/sdbench/cases nejm_cases.jsonl
+   ```
+
+2. **Train the model**
+   Run `scripts/train_domain_model.py` with a base model and the prepared
+   dataset. The example below performs one epoch of causal language modelling:
+
+   ```bash
+   python scripts/train_domain_model.py mistral-base nejm_cases.jsonl models/nejm
+   ```
+
+   The script uses `transformers.Trainer` and saves the fine-tuned weights to the
+   specified output directory.
+
+3. **Configure Dx0**
+   Start the CLI with `--llm-provider hf-local` and pass the model path via
+   `--hf-model` or set `hf_model` in the YAML configuration file:
+
+   ```yaml
+   hf_model: models/nejm
+   ```
+
+   The `HFLocalClient` loads the model using `transformers.pipeline` and can be
+   selected just like the OpenAI or Ollama providers.

--- a/scripts/prepare_finetune.py
+++ b/scripts/prepare_finetune.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""Prepare NEJM case corpus for language model fine-tuning."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Iterable
+
+
+def load_cases(src_dir: str) -> Iterable[dict]:
+    for name in sorted(os.listdir(src_dir)):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(src_dir, name)
+        with open(path, "r", encoding="utf-8") as fh:
+            yield json.load(fh)
+
+
+def build_record(case: dict) -> dict[str, str]:
+    steps = case.get("steps", [])
+    text = "\n\n".join(step.get("text", "") for step in steps)
+    prompt = f"Case ID: {case.get('id')}\n{text}\n\nDiagnosis:".strip()
+    diagnosis = steps[-1].get("text", "").strip() if steps else ""
+    return {"prompt": prompt, "completion": " " + diagnosis}
+
+
+def prepare_dataset(src_dir: str, dest_file: str) -> None:
+    records = [build_record(case) for case in load_cases(src_dir)]
+    with open(dest_file, "w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+
+
+def main(args: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Create JSONL file for fine-tuning")
+    parser.add_argument("src", help="Directory with case JSON files")
+    parser.add_argument("dest", help="Output JSONL file")
+    parsed = parser.parse_args(args)
+    prepare_dataset(parsed.src, parsed.dest)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/train_domain_model.py
+++ b/scripts/train_domain_model.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Fine-tune a language model on the prepared NEJM dataset."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from datasets import load_dataset
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    DataCollatorForLanguageModeling,
+    Trainer,
+    TrainingArguments,
+)
+
+
+def train(model_name: str, data_path: str, output_dir: str) -> None:
+    dataset = load_dataset("json", data_files=data_path, split="train")
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    dataset = dataset.map(lambda x: tokenizer(x["prompt"], truncation=True), batched=True)
+    collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+    args = TrainingArguments(output_dir=output_dir, num_train_epochs=1)
+    trainer = Trainer(model=model, args=args, train_dataset=dataset, data_collator=collator)
+    trainer.train()
+    trainer.save_model(output_dir)
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Fine-tune a local model")
+    parser.add_argument("model", help="Base model name or path")
+    parser.add_argument("data", help="JSONL file from prepare_finetune.py")
+    parser.add_argument("output", help="Directory to save the fine-tuned model")
+    parsed = parser.parse_args(args)
+    train(parsed.model, parsed.data, parsed.output)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -8,7 +8,12 @@ from .protocol import ActionType, build_action
 from .actions import PanelAction, parse_panel_action
 from .panel import VirtualPanel
 from .decision import DecisionEngine, RuleEngine, LLMEngine
-from .llm_client import LLMClient, OpenAIClient, OllamaClient
+from .llm_client import (
+    LLMClient,
+    OpenAIClient,
+    OllamaClient,
+    HFLocalClient,
+)
 from .orchestrator import Orchestrator
 from .evaluation import Evaluator, async_batch_evaluate, batch_evaluate
 from .logging_config import configure_logging
@@ -62,6 +67,7 @@ __all__ = [
     "LLMClient",
     "OpenAIClient",
     "OllamaClient",
+    "HFLocalClient",
     "VirtualPanel",
     "Orchestrator",
     "BudgetManager",

--- a/sdb/config.py
+++ b/sdb/config.py
@@ -11,6 +11,7 @@ class Settings(BaseModel):
 
     openai_api_key: Optional[str] = None
     openai_model: str = "gpt-4"
+    hf_model: Optional[str] = None
     ollama_base_url: HttpUrl = "http://localhost:11434"
     metrics_port: int = 8000
     semantic_retrieval: bool = False
@@ -63,6 +64,8 @@ def load_settings(path: str | None = None) -> Settings:
         data["openai_api_key"] = env("OPENAI_API_KEY")
     if "openai_model" not in data and env("OPENAI_MODEL"):
         data["openai_model"] = env("OPENAI_MODEL")
+    if "hf_model" not in data and env("HF_MODEL"):
+        data["hf_model"] = env("HF_MODEL")
     if "ollama_base_url" not in data and env("OLLAMA_BASE_URL"):
         data["ollama_base_url"] = env("OLLAMA_BASE_URL")
     if "metrics_port" not in data and env("SDB_METRICS_PORT"):

--- a/tasks.yml
+++ b/tasks.yml
@@ -523,6 +523,14 @@ phases:
         acceptance_criteria:
           - "New features are functional and intuitive."
 
+      - id: "T45"
+        title: "Fine-tune Domain-Specific LLM"
+        description: >
+          Train a custom language model on the NEJM case corpus and
+          integrate it through the multi-provider LLM engine.
+        labels: [feature, ai, data]
+        status: done
+
 - id: 45
   title: Secure Web UI Authentication
   description: >

--- a/tests/test_hf_local_client.py
+++ b/tests/test_hf_local_client.py
@@ -1,0 +1,23 @@
+import json
+import types
+from sdb.llm_client import HFLocalClient
+
+
+class DummyPipe:
+    def __call__(self, text, max_new_tokens=64):
+        return [{"generated_text": text + " reply"}]
+
+
+def test_hf_local_client(monkeypatch, tmp_path):
+    monkeypatch.setattr("transformers.pipeline", lambda *a, **k: DummyPipe())
+    cache_file = tmp_path / "cache.jsonl"
+    client = HFLocalClient("model", cache_path=str(cache_file))
+    msg = [{"role": "user", "content": "hello"}]
+    out = client.chat(msg, "m")
+    assert out == "reply"
+    with open(cache_file, "r", encoding="utf-8") as fh:
+        lines = fh.readlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["value"] == "reply"
+


### PR DESCRIPTION
## Summary
- add scripts for preparing the NEJM corpus and training a local model
- support loading Hugging Face models via `HFLocalClient`
- expose new `--hf-model` flag and document usage
- describe fine-tuning workflow in docs
- record completed task in `tasks.yml`
- add unit test for `HFLocalClient`

## Testing
- `pip install -q -r requirements.lock`
- `pip install -q PyJWT`
- `pytest tests/test_hf_local_client.py::test_hf_local_client -q`
- `pytest -q` *(fails: OptionInfo object has no attribute 'value')*

------
https://chatgpt.com/codex/tasks/task_e_6872ea5a97cc832abec6f4fa93227383