### PR TITLE
Add Playwright tests for UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           ./scripts/install_dev_deps.sh
+      - name: Install Playwright browsers
+        run: playwright install --with-deps chromium
       - name: Install license tools
         run: pip install pip-licenses
       - name: Check licenses

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,3 +36,4 @@ opentelemetry-exporter-jaeger==1.21.0
 bcrypt==4.3.0
 
 dvc[s3]==3.61.0  # Dataset versioning tool with S3 remote
+playwright==1.43.0  # UI end-to-end testing

--- a/requirements.lock
+++ b/requirements.lock
@@ -191,6 +191,8 @@ googleapis-common-protos==1.59.1
     # via opentelemetry-exporter-jaeger-proto-grpc
 grandalf==0.8
     # via dvc
+greenlet==3.0.3
+    # via playwright
 grpcio==1.73.1
     # via opentelemetry-exporter-jaeger-proto-grpc
 gto==1.7.2
@@ -371,6 +373,8 @@ platformdirs==4.3.8
     #   black
     #   dvc
     #   virtualenv
+playwright==1.43.0
+    # via -r requirements-dev.txt
 pluggy==1.6.0
     # via pytest
 pre-commit==4.2.0
@@ -403,6 +407,8 @@ pydantic-core==2.33.2
     # via pydantic
 pydot==4.0.1
     # via dvc
+pyee==11.1.0
+    # via playwright
 pyflakes==3.4.0
     # via flake8
 pygit2==1.18.0
@@ -417,6 +423,8 @@ pygtrie==2.5.0
     #   dvc-data
     #   scmrepo
     #   sqltrie
+pyjwt==2.8.0
+    # via -r requirements-dev.txt
 pyparsing==3.2.3
     # via
     #   dvc
@@ -559,6 +567,7 @@ typing-extensions==4.14.1
     #   opentelemetry-semantic-conventions
     #   pydantic
     #   pydantic-core
+    #   pyee
     #   sentence-transformers
     #   torch
     #   typer

--- a/tasks.yml
+++ b/tasks.yml
@@ -1520,7 +1520,7 @@ phases:
   area: frontend
   dependencies: []
   priority: 3
-  status: todo
+  status: done
   actionable_steps:
     - Implement Playwright or Cypress tests covering keyboard navigation and ARIA labels.
     - Verify dark mode styles in automated tests.

--- a/tests/test_e2e_ui_playwright.py
+++ b/tests/test_e2e_ui_playwright.py
@@ -1,0 +1,54 @@
+import threading
+import time
+import uvicorn
+
+from playwright.sync_api import sync_playwright
+
+import sdb.ui.app as ui_app
+
+app = ui_app.app
+
+
+def _start_server(port: int):
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    while not server.started:
+        time.sleep(0.05)
+    return server, thread
+
+
+def _stop_server(server: uvicorn.Server, thread: threading.Thread) -> None:
+    server.should_exit = True
+    thread.join()
+
+
+def test_accessibility_roles():
+    """UI exposes regions and focus outlines."""
+    server, thread = _start_server(8020)
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+        page.goto("http://127.0.0.1:8020/api/v1")
+        regions = page.locator("[role=region]")
+        assert regions.count() >= 4
+        page.locator("button").first.focus()
+        outline = page.evaluate("getComputedStyle(document.activeElement).outlineStyle")
+        assert outline != "none"
+        browser.close()
+    _stop_server(server, thread)
+
+
+def test_dark_mode_colors():
+    """Dark theme sets expected background color."""
+    server, thread = _start_server(8021)
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+        page.goto("http://127.0.0.1:8021/api/v1")
+        page.evaluate("document.documentElement.setAttribute('data-theme','dark')")
+        bg = page.evaluate("getComputedStyle(document.body).backgroundColor")
+        assert bg == "rgb(36, 36, 36)"
+        browser.close()
+    _stop_server(server, thread)


### PR DESCRIPTION
## Summary
- add Playwright-based E2E tests
- install Playwright browser in CI
- add Playwright dependency and regenerate lock file
- mark UI test coverage task done

## Testing
- `pip install pip-tools pip-audit` *(for lock update)*
- `pip install playwright==1.43.0`
- `playwright install chromium`
- `pytest -q` *(fails: test_cli_flag_parsing, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6872fe2a3f88832aae203724a698aaf5