### PR TITLE
Add Kubernetes manifests and staging test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,25 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           files: dist/*
+  staging:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run container
+        run: |
+          docker run -d --name dx0-test -p 8000:8000 ghcr.io/${{ github.repository }}:${{ github.ref_name }} \
+            uvicorn sdb.ui.app:app --host 0.0.0.0 --port 8000
+          sleep 10
+      - name: Health check
+        run: curl -f http://localhost:8000/docs > /dev/null
+      - name: Show logs
+        if: always()
+        run: docker logs dx0-test
+      - name: Cleanup
+        if: always()
+        run: docker rm -f dx0-test

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -215,6 +215,21 @@ docker compose up
 
 The Dx0 API is available on [http://localhost:8000](http://localhost:8000), Prometheus on port `9090`, and Grafana on `3000`.
 
+## Kubernetes Setup
+
+If you prefer Kubernetes, apply the manifests in the `k8s` directory:
+
+```bash
+kubectl apply -f k8s/
+```
+
+Port-forward the API service with:
+
+```bash
+kubectl port-forward service/dx0 8000:8000
+```
+
+
 ## Testing
 
 Install the development dependencies and run the test suite:

--- a/k8s/dx0.yaml
+++ b/k8s/dx0.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dx0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dx0
+  template:
+    metadata:
+      labels:
+        app: dx0
+    spec:
+      containers:
+        - name: dx0
+          image: ghcr.io/mai-dxo/dx0:latest
+          command: ["uvicorn", "sdb.ui.app:app", "--host", "0.0.0.0", "--port", "8000"]
+          ports:
+            - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dx0
+spec:
+  selector:
+    app: dx0
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000

--- a/k8s/monitoring.yaml
+++ b/k8s/monitoring.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    scrape_configs:
+      - job_name: 'dx0'
+        static_configs:
+          - targets: ['dx0:8000']
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:latest
+          args: ["--config.file=/etc/prometheus/prometheus.yml"]
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus/prometheus.yml
+              subPath: prometheus.yml
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - protocol: TCP
+      port: 9090
+      targetPort: 9090
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:latest
+          ports:
+            - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  selector:
+    app: grafana
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000


### PR DESCRIPTION
## Summary
- add Kubernetes manifests for dx0, Prometheus and Grafana
- document how to deploy with kubectl
- extend release workflow to run container image in a staging job

## Testing
- `./scripts/install_dev_deps.sh`
- `pytest -q` *(fails: 15 failed, 163 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68730e451954832a842ae0ff0dabdd16