### PR TITLE
Add security audit report and threat model

### DIFF
--- a/docs/security_report.md
+++ b/docs/security_report.md
@@ -16,3 +16,19 @@ $ pip-audit -r requirements-dev.txt
 
 Monitor upstream releases of PyTorch and upgrade when a version addressing GHSA-887c-mr87-cxwp becomes available. Until then ensure that untrusted input is not passed to vulnerable APIs.
 
+---
+
+The project was also scanned with `safety` using the locked dependencies:
+
+```
+$ safety check -r requirements.lock
+```
+
+### Additional Findings
+
+- **pyjwt 2.8.0** – vulnerability [CVE-2024-53861](https://data.safetycli.com/v/74429/97c) allows issuer claim bypass due to partial string comparison.
+
+### Mitigation
+
+Upgrade `pyjwt` to version 2.10.1 or later which resolves the partial comparison issue.
+

--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -1,0 +1,36 @@
+# Threat Model Overview
+
+This document summarizes key security considerations for Dx0.
+
+## Authentication
+
+User accounts for the web UI are defined in `sdb/ui/users.yml`. Passwords are stored as bcrypt hashes. The path can be overridden with the `UI_USERS_FILE` environment variable. Session tokens for the CLI are saved to `~/.dx0/token.json` with permissions `0600`.
+
+**Threats**: credential theft, weak passwords, unauthorized access.
+
+**Mitigations**:
+- Use strong, unique passwords when adding entries to `users.yml`.
+- Protect the token file with correct file permissions and avoid committing it to version control.
+- Limit network exposure of the UI and use HTTPS in production deployments.
+
+## Data Storage
+
+Case data and evaluation metrics can be stored in JSON or SQLite databases. Example paths include `cases.db` and `results.db`. Some scripts support uploading data to S3 via DVC.
+
+**Threats**: unauthorized access or tampering with case data; leakage of PHI if real patient cases are used.
+
+**Mitigations**:
+- Restrict file permissions on local databases.
+- Use access controls on any remote storage such as S3 buckets.
+- Ensure only de‑identified cases are stored in shared locations.
+
+## Logging
+
+Structured logs are emitted via `structlog` and may include panel actions and metrics. Metrics can also be exported to Prometheus.
+
+**Threats**: log injection or exposure of sensitive information in logs.
+
+**Mitigations**:
+- Sanitize user input before logging.
+- Limit log retention and restrict access to log storage.
+


### PR DESCRIPTION
## Summary
- document safety audit findings for pyjwt
- add threat model overview

## Testing
- `pip-audit -r requirements.lock` *(failed: KeyboardInterrupt)*
- `safety check -r requirements.lock`
- `pytest -q` *(failed to collect tests)*

------
https://chatgpt.com/codex/tasks/task_e_6873137a11d4832ab3d7bc2cee8391a5