### PR TITLE
Add plugin packaging guidance and sample repos

### DIFF
--- a/docs/cost_estimator_plugins.md
+++ b/docs/cost_estimator_plugins.md
@@ -53,5 +53,6 @@ my_estimator/
 ├── pyproject.toml
 └── my_package.py
 ```
+An example implementation is available in `examples/cost_estimator_plugin/`.
 
 Select the plugin with `--cost-estimator` or set `SDB_COST_ESTIMATOR` in the environment. The default `csv` plugin uses `CostEstimator.load_from_csv`.

--- a/docs/persona_plugins.md
+++ b/docs/persona_plugins.md
@@ -32,3 +32,13 @@ pip install -e path/to/my_plugin
 
 After installation, you can instantiate a panel with
 `VirtualPanel(persona_chain="my-chain")`.
+
+## Example Repository Layout
+
+```
+persona_plugin/
+├── pyproject.toml
+└── my_persona.py
+```
+
+A minimal implementation lives in `examples/persona_plugin/`.

--- a/docs/retrieval_plugins.md
+++ b/docs/retrieval_plugins.md
@@ -33,7 +33,9 @@ pip install -e path/to/my_plugin
 
 ## Packaging & Versioning
 
-Create a small Python package with a `pyproject.toml` describing your plugin:
+Create a small Python package with a `pyproject.toml` describing your plugin.
+Give the package a unique name (for example `sdb-my-index`) and list `sdb` as a
+dependency:
 
 ```toml
 [project]
@@ -45,7 +47,16 @@ dependencies = ["sdb"]
 my-index = "my_plugin:MyIndex"
 ```
 
-Use [semantic versioning](https://semver.org/) when updating your plugin. Install it in editable mode while developing or build a wheel with `python -m build` for distribution.
+Use [semantic versioning](https://semver.org/) when updating your plugin. Install
+the package in editable mode while developing:
+
+```bash
+pip install -e .
+```
+
+When publishing a new release, build a wheel with `python -m build` and upload it
+to PyPI using `twine upload dist/*`. Tag releases in Git so version history is
+clear.
 
 ## Example Repository Layout
 
@@ -55,4 +66,7 @@ my_index/
 └── my_plugin.py
 ```
 
-After installation, set `retrieval_backend` in `settings.yaml` (or the `SDB_RETRIEVAL_BACKEND` environment variable) to `my-index` and enable semantic retrieval to use your custom backend.
+An example implementation is provided in `examples/retrieval_plugin/`. After
+installation, set `retrieval_backend` in `settings.yaml` (or the
+`SDB_RETRIEVAL_BACKEND` environment variable) to `my-index` and enable semantic
+retrieval to use your custom backend.

--- a/examples/cost_estimator_plugin/my_estimator.py
+++ b/examples/cost_estimator_plugin/my_estimator.py
@@ -1,0 +1,7 @@
+from sdb.cost_estimator import CostEstimator, CptCost
+
+
+def fixed_price_estimator(path: str) -> CostEstimator:
+    """Return a simple estimator ignoring ``path``."""
+    table = {"cbc": CptCost("100", 1.0)}
+    return CostEstimator(table)

--- a/examples/cost_estimator_plugin/pyproject.toml
+++ b/examples/cost_estimator_plugin/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dx0-example-estimator"
+version = "0.1.0"
+dependencies = ["sdb"]
+
+[project.entry-points."dx0.cost_estimators"]
+fixed = "my_estimator:fixed_price_estimator"

--- a/examples/persona_plugin/my_persona.py
+++ b/examples/persona_plugin/my_persona.py
@@ -1,0 +1,6 @@
+from typing import List
+
+
+def cheerleader_persona() -> List[str]:
+    """Return the prompt chain for an encouraging persona."""
+    return ["cheerleader_system", "cheerleader_user"]

--- a/examples/persona_plugin/pyproject.toml
+++ b/examples/persona_plugin/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dx0-example-persona"
+version = "0.1.0"
+dependencies = ["sdb"]
+
+[project.entry-points."dx0.personas"]
+cheerleader = "my_persona:cheerleader_persona"

--- a/examples/retrieval_plugin/my_plugin.py
+++ b/examples/retrieval_plugin/my_plugin.py
@@ -1,0 +1,16 @@
+from typing import List, Tuple
+from sdb.retrieval import BaseRetrievalIndex
+
+class ExampleIndex(BaseRetrievalIndex):
+    """Minimal retrieval backend returning a fixed ranking."""
+
+    def __init__(self, documents: List[str]):
+        self.documents = documents
+
+    def query(self, text: str, top_k: int = 1) -> List[Tuple[str, float]]:
+        scores = [
+            (doc, float(len(set(text.split()) & set(doc.split()))))
+            for doc in self.documents
+        ]
+        scores.sort(key=lambda pair: pair[1], reverse=True)
+        return scores[:top_k]

--- a/examples/retrieval_plugin/pyproject.toml
+++ b/examples/retrieval_plugin/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sdb-example-index"
+version = "0.1.0"
+dependencies = ["sdb"]
+
+[project.entry-points."sdb.retrieval_plugins"]
+example-index = "my_plugin:ExampleIndex"


### PR DESCRIPTION
## Summary
- elaborate on retrieval plugin packaging and versioning
- mention example plugin repositories for retrieval, persona, and cost estimator
- add sample plugin packages under `examples/`

## Testing
- `pytest -q` *(fails: 16 failed, 163 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68731b2a526c832aa5674ecc219b4972