### PR TITLE
Log LLM fallback warnings

### DIFF
--- a/sdb/decision.py
+++ b/sdb/decision.py
@@ -198,10 +198,12 @@ class LLMEngine(DecisionEngine):
             model = self.persona_models.get(name, self.model)
             reply = self._chat(messages, model)
             if reply is None:
+                logger.warning("llm_fallback", reason="no_reply")
                 return self.fallback.decide(context)
             messages.append({"role": "assistant", "content": reply})
         action = parse_panel_action(messages[-1]["content"])
         if action is None:
+            logger.warning("llm_fallback", reason="parse")
             return self.fallback.decide(context)
         logger.info(
             "llm_decision",
@@ -228,6 +230,7 @@ class LLMEngine(DecisionEngine):
             for system, user, reply in results:
                 messages.extend([system, user])
                 if reply is None:
+                    logger.warning("llm_fallback", reason="no_reply")
                     return await asyncio.to_thread(self.fallback.decide, context)
                 messages.append({"role": "assistant", "content": reply})
         else:
@@ -238,10 +241,12 @@ class LLMEngine(DecisionEngine):
                 model = self.persona_models.get(name, self.model)
                 reply = await self._achat(messages, model)
                 if reply is None:
+                    logger.warning("llm_fallback", reason="no_reply")
                     return await asyncio.to_thread(self.fallback.decide, context)
                 messages.append({"role": "assistant", "content": reply})
         action = parse_panel_action(messages[-1]["content"])
         if action is None:
+            logger.warning("llm_fallback", reason="parse")
             return await asyncio.to_thread(self.fallback.decide, context)
         logger.info(
             "llm_decision",

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -1,0 +1,76 @@
+import logging
+import sys
+import types
+import importlib.util
+import pathlib
+import pytest
+
+import logging
+import structlog
+
+sys.modules.setdefault("xmlschema", types.ModuleType("xmlschema"))
+sys.modules.setdefault("opentelemetry", types.ModuleType("opentelemetry"))
+sys.modules.setdefault("opentelemetry.trace", types.ModuleType("opentelemetry.trace"))
+pkg_path = pathlib.Path(__file__).resolve().parents[1] / "sdb"
+spec = importlib.util.spec_from_loader("sdb", loader=None, is_package=True)
+assert spec is not None
+spec.submodule_search_locations = [str(pkg_path)]
+pkg = importlib.util.module_from_spec(spec)
+pkg.__path__ = [str(pkg_path)]
+sys.modules["sdb"] = pkg
+
+def configure_logging():
+    logging.basicConfig(level=logging.WARNING, format="%(message)s")
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(logging.WARNING),
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.JSONRenderer(),
+        ],
+    )
+
+configure_logging()
+
+DECISION_SPEC = importlib.util.spec_from_file_location(
+    "sdb.decision", pathlib.Path(__file__).resolve().parents[1] / "sdb" / "decision.py"
+)
+decision = importlib.util.module_from_spec(DECISION_SPEC)
+assert DECISION_SPEC and DECISION_SPEC.loader
+sys.modules["sdb.decision"] = decision
+DECISION_SPEC.loader.exec_module(decision)
+
+LLMEngine = decision.LLMEngine
+Context = decision.Context
+LLMClient = decision.LLMClient
+from sdb.protocol import ActionType
+
+
+class NoneReplyClient(LLMClient):
+    def _chat(self, messages, model):
+        return None
+
+
+class InvalidReplyClient(LLMClient):
+    def _chat(self, messages, model):
+        return "nonsense"
+
+
+def test_warning_on_no_reply(capsys):
+    engine = LLMEngine(client=NoneReplyClient())
+    ctx = Context(turn=2, past_infos=["info"], triggered_keywords=set())
+    action = engine.decide(ctx)
+    assert action.action_type == ActionType.TEST
+    out = capsys.readouterr().out
+    assert "llm_fallback" in out
+    assert "no_reply" in out
+
+
+def test_warning_on_parse_failure(capsys):
+    engine = LLMEngine(client=InvalidReplyClient())
+    ctx = Context(turn=2, past_infos=["info"], triggered_keywords=set())
+    action = engine.decide(ctx)
+    assert action.action_type == ActionType.TEST
+    out = capsys.readouterr().out
+    assert "llm_fallback" in out
+    assert "parse" in out


### PR DESCRIPTION
## Summary
- log warnings when LLMEngine falls back to RuleEngine
- add tests verifying warnings on missing or invalid LLM replies

## Testing
- `pytest tests/test_llm_fallback.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: xmlschema)*

------
https://chatgpt.com/codex/tasks/task_e_687346955418832abd2e5cc9ff9e7044