### PR TITLE
Update Playwright installation in dev deps script

### DIFF
--- a/scripts/install_dev_deps.sh
+++ b/scripts/install_dev_deps.sh
@@ -9,4 +9,5 @@ cd "$repo_root"
 pip install -r requirements.lock
 
 # Install browsers for the Playwright test suite
-playwright install chromium
+# Install all supported browsers (chromium, firefox, and webkit)
+playwright install


### PR DESCRIPTION
## Summary
- install all Playwright browsers when provisioning dev deps

## Testing
- `bash scripts/install_dev_deps.sh` *(fails: Installing collected packages)*
- `pytest -q` *(fails to collect tests)*

------
https://chatgpt.com/codex/tasks/task_e_687357fd0194832aa2551b66429ac948