### PR TITLE
Clarify browser install step

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -232,8 +232,8 @@ kubectl port-forward service/dx0 8000:8000
 
 ## Testing
 
-Install the development dependencies and run the test suite. The helper script
-also downloads the browsers used by the Playwright UI tests:
+Run the helper script to install the development dependencies **and all
+Playwright browsers required by the UI tests**, then execute the test suite:
 
 ```bash
 ./scripts/install_dev_deps.sh


### PR DESCRIPTION
## Summary
- update testing instructions to explain playwright browser setup

## Testing
- `./scripts/install_dev_deps.sh`
- `pytest -q` *(passes: 27 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68735bc7b740832a90e039bc43674828