### PR TITLE
Update changelog for 0.4.0 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 - `BudgetManager` service to track session spending and enforce limits.
 - `--budget-limit` CLI flag and `UI_BUDGET_LIMIT` environment variable.
+### Fixed
+- Exposed `HFLocalClient` at the package root.
+- Added side-effect import for the `metrics` module.
+- Adjusted retrieval latency measurement timing.
 
 ## [0.3.0] - 2024-??-??
 ### Added


### PR DESCRIPTION
## Summary
- document HFLocalClient exposure and metrics import
- note retrieval latency measurement tweak

## Testing
- `pytest -q` *(interrupted after ~60 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68743a166714832a8777a55e4525bcdb