### PR TITLE
Add missing docstrings for modules and methods

### DIFF
--- a/sdb/services/budget.py
+++ b/sdb/services/budget.py
@@ -1,3 +1,5 @@
+"""Budget tracking utilities for enforcing spending limits."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -25,6 +27,7 @@ class BudgetManager:
     test_categories: Dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        """Load existing budget state from storage, if configured."""
         if self.store is not None:
             self.spent = self.store.total()
         if self.session_db is not None and self.session_token is not None:

--- a/sdb/services/budget_store.py
+++ b/sdb/services/budget_store.py
@@ -1,3 +1,5 @@
+"""SQLite-backed storage for test spending information."""
+
 from __future__ import annotations
 
 import sqlite3
@@ -7,6 +9,7 @@ class BudgetStore:
     """Persist test spending amounts using SQLite."""
 
     def __init__(self, path: str) -> None:
+        """Create a new store backed by ``path``."""
         self.path = path
         self._init_db()
 

--- a/sdb/services/metrics_db.py
+++ b/sdb/services/metrics_db.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """SQLite storage for session evaluation metrics."""
+
+from __future__ import annotations
 
 import sqlite3
 from typing import Iterable
@@ -12,6 +12,7 @@ class MetricsDB:
     """Persist :class:`SessionResult` records in SQLite."""
 
     def __init__(self, path: str) -> None:
+        """Initialize the database at ``path`` and create tables."""
         self.path = path
         self._init_db()
 

--- a/sdb/services/results.py
+++ b/sdb/services/results.py
@@ -1,10 +1,12 @@
-from __future__ import annotations
+"""Helpers for tracking ordered tests and final diagnoses."""
 
+from __future__ import annotations
 
 class ResultAggregator:
     """Collect ordered tests and final diagnosis."""
 
     def __init__(self) -> None:
+        """Initialize empty result tracking structures."""
         self.ordered_tests: list[str] = []
         self.final_diagnosis: str | None = None
         self.finished: bool = False

--- a/sdb/token.py
+++ b/sdb/token.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utility functions for CLI session tokens."""
+
+from __future__ import annotations
 
 import json
 import os

--- a/sdb/ui/app.py
+++ b/sdb/ui/app.py
@@ -278,6 +278,7 @@ class UserPanel:
     """Panel that feeds user actions into the orchestrator."""
 
     def __init__(self) -> None:
+        """Initialize the empty action queue."""
         self.actions: asyncio.Queue[PanelAction] = asyncio.Queue()
         self.turn = 0
 
@@ -305,6 +306,7 @@ async def migrate_store() -> None:
 
 @app.on_event("startup")
 async def start_cleanup() -> None:
+    """Spawn a background task to purge expired sessions."""
     async def _loop() -> None:
         while True:
             SESSION_STORE.cleanup()


### PR DESCRIPTION
## Summary
- add module docstrings to utility modules
- document BudgetManager.__post_init__ and background cleanup
- document results aggregation and budget store init
- update UserPanel constructor docs

## Testing
- `pydocstyle sdb/token.py sdb/services/budget.py sdb/services/budget_store.py sdb/services/metrics_db.py sdb/services/results.py sdb/ui/app.py`
- `pytest -q` *(tests passed)*


------
https://chatgpt.com/codex/tasks/task_e_687455b92514832a96401d8a03585978