### PR TITLE
Fix retrieval plugin format

### DIFF
--- a/examples/retrieval_plugin/my_plugin.py
+++ b/examples/retrieval_plugin/my_plugin.py
@@ -1,7 +1,5 @@
 from typing import List, Tuple
 from sdb.retrieval import BaseRetrievalIndex
-
-
 class ExampleIndex(BaseRetrievalIndex):
     """Minimal retrieval backend returning a fixed ranking."""
 


### PR DESCRIPTION
## Summary
- remove extra blank line before `ExampleIndex` in the retrieval plugin example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874bb2a0350832ab695e2327687bf2e