### PR TITLE
Add metrics to export list

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -28,7 +28,7 @@ from .ingest.pipeline import run_pipeline, update_dataset
 from .ingest.translate import translate_directory
 from .cpt_lookup import lookup_cpt
 from .metrics import start_metrics_server
-from . import metrics  # noqa: F401
+from . import metrics
 from .retrieval import (
     SimpleEmbeddingIndex,
     FaissIndex,
@@ -84,6 +84,7 @@ __all__ = [
     "load_from_sqlite",
     "save_to_sqlite",
     "start_metrics_server",
+    "metrics",
     "SimpleEmbeddingIndex",
     "FaissIndex",
     "SentenceTransformerIndex",

--- a/sdb/services/results.py
+++ b/sdb/services/results.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+
 class ResultAggregator:
     """Collect ordered tests and final diagnosis."""
 


### PR DESCRIPTION
## Summary
- export `metrics` from the package and remove the unused-import ignore
- fix lint in `sdb/services/results.py`

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'starlette')*

------
https://chatgpt.com/codex/tasks/task_e_6874eb336b80832a85644a76fe8d09c1