### PR TITLE
Fix retrieval cache timing

### DIFF
--- a/sdb/retrieval.py
+++ b/sdb/retrieval.py
@@ -58,9 +58,9 @@ class CachedRetrievalIndex:
         if hit and now - hit[0] < self.ttl:
             RETRIEVAL_CACHE_HITS.inc()
             return hit[1]
-        start = time.time()
+        start = time.perf_counter()
         results = self.backend.query(text, top_k=top_k)
-        duration = time.time() - start
+        duration = time.perf_counter() - start
         RETRIEVAL_LATENCY.observe(duration)
         self.cache[key] = (now, results)
         return results

--- a/tests/test_retrieval_cache.py
+++ b/tests/test_retrieval_cache.py
@@ -15,7 +15,8 @@ class DummyIndex:
 def test_cache_hit(monkeypatch):
     base = DummyIndex()
     cache = retrieval.CachedRetrievalIndex(base, ttl=10)
-    monkeypatch.setattr(retrieval, "time", types.SimpleNamespace(time=lambda: 0))
+    monkeypatch.setattr(retrieval.time, "time", lambda: 0)
+    monkeypatch.setattr(retrieval.time, "perf_counter", lambda: 0)
     first = cache.query("q")
     second = cache.query("q")
     assert first == second
@@ -25,7 +26,8 @@ def test_cache_hit(monkeypatch):
 def test_cache_expiry(monkeypatch):
     base = DummyIndex()
     now = [0]
-    monkeypatch.setattr(retrieval, "time", types.SimpleNamespace(time=lambda: now[0]))
+    monkeypatch.setattr(retrieval.time, "time", lambda: now[0])
+    monkeypatch.setattr(retrieval.time, "perf_counter", lambda: now[0])
     cache = retrieval.CachedRetrievalIndex(base, ttl=5)
     cache.query("q")
     now[0] = 6


### PR DESCRIPTION
## Summary
- use `time.perf_counter()` for measuring retrieval latency
- patch `time.perf_counter` in retrieval cache tests

## Testing
- `pytest -q tests/test_retrieval_cache.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874ed57a69c832a8348d7b9a28615b6