### PR TITLE
Add release notes automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip build
           python -m build -w
+      - name: Generate release notes
+        run: python scripts/generate_release_notes.py --output release_notes.md
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -45,6 +47,7 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           files: dist/*
+          body_path: release_notes.md
   staging:
     needs: release
     runs-on: ubuntu-latest

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,18 @@
+# Release Workflow
+
+This project publishes a new version whenever a tag matching `v*.*.*` is pushed.
+The GitHub Actions workflow builds the Docker image and Python wheel,
+uploads them, and creates a GitHub release.
+
+Release notes are assembled automatically from commit messages using the
+`scripts/generate_release_notes.py` helper.
+
+## Steps to cut a release
+
+1. Run `python scripts/generate_release_notes.py` to update
+   `docs/release_notes.md` with changes since the last tag.
+2. Commit the updated notes and push them to the `main` branch.
+3. Create a signed tag for the new version, e.g. `git tag -s v1.2.0 -m "v1.2.0"`.
+4. Push the tag with `git push origin v1.2.0`.
+5. The workflow will publish artifacts and use the generated notes as the
+   body of the GitHub release.

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -1,0 +1,63 @@
+"""Generate release notes from Git commit history."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+from datetime import date
+from pathlib import Path
+
+
+def git(*args: str) -> str:
+    """Run a git command and return its output."""
+    result = subprocess.run(
+        ["git", *args], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
+    return result.stdout.strip()
+
+
+def gather_messages(since_tag: str) -> list[str]:
+    log_range = f"{since_tag}..HEAD" if since_tag else "HEAD"
+    output = git("log", log_range, "--pretty=format:%s")
+    messages = []
+    for line in output.splitlines():
+        if line and not line.startswith("Merge"):
+            messages.append(line)
+    return messages
+
+
+def update_file(path: Path, header: str, notes: list[str]) -> None:
+    if path.exists():
+        existing = path.read_text()
+    else:
+        existing = ""
+
+    lines = existing.splitlines()
+    if lines and lines[0].startswith("#"):
+        content = "\n".join(lines[1:])
+        new_text = f"{lines[0]}\n\n{header}\n" + "\n".join(f"* {m}" for m in notes) + "\n\n" + content
+    else:
+        new_text = f"# Release Notes\n\n{header}\n" + "\n".join(f"* {m}" for m in notes) + "\n\n" + existing
+    path.write_text(new_text)
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Assemble release notes")
+    parser.add_argument("--since-tag", help="Tag to start from. Defaults to latest tag")
+    parser.add_argument("--output", default="docs/release_notes.md", help="File to update")
+    ns = parser.parse_args(args)
+
+    if ns.since_tag:
+        tag = ns.since_tag
+    else:
+        try:
+            tag = git("describe", "--tags", "--abbrev=0")
+        except subprocess.CalledProcessError:
+            tag = ""
+    messages = gather_messages(tag)
+    today = date.today().isoformat()
+    header = f"## Unreleased - {today}"
+    update_file(Path(ns.output), header, messages)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate release notes from commits using `scripts/generate_release_notes.py`
- integrate release notes step in the release GitHub Action
- document the release workflow in `docs/release.md`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68750eb8c384832abbb82f439c554767