### PR TITLE
Add async retrieval interfaces

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -34,6 +34,7 @@ from .retrieval import (
     FaissIndex,
     SentenceTransformerIndex,
     CrossEncoderReranker,
+    AsyncRetrievalIndex,
     get_retrieval_plugin,
 )
 from .plugins import PluginInfo, validate_plugins
@@ -89,6 +90,7 @@ __all__ = [
     "FaissIndex",
     "SentenceTransformerIndex",
     "CrossEncoderReranker",
+    "AsyncRetrievalIndex",
     "get_retrieval_plugin",
     "load_scores",
     "permutation_test",


### PR DESCRIPTION
## Summary
- support async retrieval with a new `AsyncRetrievalIndex` protocol
- implement async `aquery` methods for builtin indexes
- add async caching logic and async gatekeeper retrieval
- re-export `AsyncRetrievalIndex` in package init

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68763d29c178832aa115ae017c19b64e