### PR TITLE
Add drift analysis report

### DIFF
--- a/docs/drift_analysis_report.md
+++ b/docs/drift_analysis_report.md
@@ -1,0 +1,46 @@
+# Drift Analysis Report
+
+- **Expansion toward CLI docs** – The latest merge introduced Sphinx-based documentation for the command line, as shown by the new instructions in `README.md` lines 438‑447 and a new backlog item in `tasks.yml` lines 1760‑1769. This aligns with prior goals of improving documentation.
+- **Integration of Sphinx framework** – `docs/README.md` now details how to build CLI docs using `sphinx-build`, while new Sphinx configuration files (e.g., `docs/sphinx/conf.py` and `docs/sphinx/index.rst`) show intentional setup for structured documentation. No conflicting instructions found, so drift is minimal.
+- **Roadmap adherence** – The backlog entry describing Sphinx CLI docs is marked `status: done`, indicating the roadmap is being updated alongside development. This demonstrates consistency between tasks and implementation.
+
+## Decision Audit Ledger
+
+- **Decision:** Add Sphinx-based CLI documentation
+  - **Origin:** Commit introducing `docs/sphinx` structure and README update
+  - **Justified by:** Tasks.yml entry (#212) designating CLI docs as an enhancement
+  - **Breaks down if:** Sphinx dependencies aren’t installed or docs aren’t regenerated with later CLI updates
+
+- **Decision:** Introduce `sphinx-typer` and `myst-parser` dependencies
+  - **Origin:** Same commit updating `requirements-dev.txt`
+  - **Justified by:** Needed for Typer-based CLI docs generation
+  - **Breaks down if:** Future CLI changes aren’t reflected in docs or if these packages conflict with other tooling
+
+## Trajectory Assessment
+
+- **Convergent path** – The project is slowly consolidating around better documentation and structured evaluation. The tasks backlog is consistently updated.
+- **Risks** – New features may stretch maintenance if not continually documented, and expanding dependencies might complicate the build environment.
+- **Futures:**
+  1. **Stable release** – With ongoing cleanup and documentation, the system packages into a reproducible distribution.
+  2. **Complexity creep** – Additional features without cross-task alignment cause tests and docs to drift, undermining reliability.
+  3. **Architectural pivot** – A shift to new LLM providers or decision engines introduces unplanned refactors; success hinges on clear design docs.
+
+## Schema & Structural Integrity Checks
+
+- `tasks.yml` continues to track IDs, titles, descriptions, statuses, and priorities consistently; new items follow the schema.
+- Docs are organized under `docs/` with a dedicated Sphinx subdirectory, which matches README instructions.
+- CLI documentation references the Typer app correctly via `.. typer:: cli.app` in `cli_reference.rst`.
+
+## Recommendations for Realignment
+
+1. **Automate doc generation** – Add a CI step to run `sphinx-build` to ensure CLI docs stay up to date with every release.
+2. **Cross-reference tasks and docs** – Link relevant tasks directly in the documentation so contributors see how features map to roadmap items.
+3. **Test coverage** – Ensure any new CLI options are reflected in tests; otherwise the CLI docs risk becoming aspirational rather than accurate.
+
+## Narrative Intelligence Score
+
+7/10
+
+## Agentic Harmony Score
+
+8/10

--- a/tasks.yml
+++ b/tasks.yml
@@ -1768,3 +1768,23 @@ backlog:
     status: done
     epic: Phase 4
     assigned_to: null
+  - id: 213
+    title: "Publish Drift Analysis Report"
+    description: >
+        Document the drift analysis and decision audit in `docs/drift_analysis_report.md` to track project alignment over time.
+    component: documentation
+    area: project-management
+    priority: 2
+    status: done
+    epic: Phase 4
+    assigned_to: null
+  - id: 214
+    title: "Automate Sphinx Doc Generation"
+    description: >
+        Add a CI step to run `sphinx-build` so CLI documentation stays current with every release.
+    component: devops
+    area: enhancement
+    priority: 3
+    status: pending
+    epic: Phase 4
+    assigned_to: null


### PR DESCRIPTION
## Summary
- document project drift analysis under `docs/`
- track publication and CI doc generation in `tasks.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dvc' ...)*

------
https://chatgpt.com/codex/tasks/task_e_687892f5cf64832ab1025e5a339ce189