### PR TITLE
Add Claude Code Action workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,27 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  run-claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Claude Code Action Official
+        uses: anthropics/claude-code-action@beta


### PR DESCRIPTION
## Summary
- add `.github/workflows/claude.yml` to enable Claude Code Action for PRs and issues

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after running part of the suite)*

------
https://chatgpt.com/codex/tasks/task_e_688074481ac8832ab0fb4eaecf71d7ea